### PR TITLE
Fix due to relative imports in Julia

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -1,5 +1,4 @@
 
-
 require("Codecs")
 require("Compose")
 require("DataFrames")
@@ -381,8 +380,6 @@ include("coord.jl")
 include("geometry.jl")
 include("guide.jl")
 include("statistics.jl")
-
-import Scale, Coord, Geom, Guide, Stat
 
 
 # All aesthetics must have a scale. If none is given, we use a default.


### PR DESCRIPTION
Due to changes in the way relative imports are handled in Julia, this `import` statement no longer works. It turns out that these imports are actually not needed, since these names are already available within the `Gadfly` module due to the `include` above. 

Without this change, Gadfly refuses to load in the latest HEAD of Julia master. 
