### PR TITLE
Adds x error bars.

### DIFF
--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -131,15 +131,19 @@ end
 # Checking aesthetics and giving reasonable error messages.
 
 
-# Raise an error if any of thu given aesthetics are not defined.
+# Raise an error if any of the given aesthetics are not defined.
 #
 # Args:
 #   who: A string naming the caller which is printed in the error message.
 #   aes: An Aesthetics object.
 #   vars: Symbol that must be defined in the aesthetics.
 #
+function undefined_aesthetics(aes::Aesthetics, vars::Symbol...)
+    setdiff(Set(vars...), defined_aesthetics(aes))
+end
+
 function assert_aesthetics_defined(who::String, aes::Aesthetics, vars::Symbol...)
-    undefined_vars = setdiff(Set(vars...), defined_aesthetics(aes))
+    undefined_vars = undefined_aesthetics(aes, vars...)
     if !isempty(undefined_vars)
         error(@sprintf("The following aesthetics are required by %s but are not defined: %s\n",
                        who, join(undefined_vars, ", ")))

--- a/src/geom/errorbar.jl
+++ b/src/geom/errorbar.jl
@@ -2,12 +2,27 @@
 immutable ErrorBarGeometry <: Gadfly.GeometryElement
 end
 
+immutable XErrorBarGeometry <: Gadfly.GeometryElement
+end
+
+immutable YErrorBarGeometry <: Gadfly.GeometryElement
+end
 
 const errorbar = ErrorBarGeometry
+const xerrorbar = XErrorBarGeometry
+const yerrorbar = YErrorBarGeometry
 
 
 function element_aesthetics(::ErrorBarGeometry)
+    [:x, :y, :xmin, :xmax, :ymin, :ymax]
+end
+
+function element_aesthetics(::YErrorBarGeometry)
     [:x, :ymin, :ymax]
+end
+
+function element_aesthetics(::XErrorBarGeometry)
+    [:y, :xmin, :xmax]
 end
 
 
@@ -22,6 +37,21 @@ end
 #   A compose Form.
 #
 function render(geom::ErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
+    # check for X and Y error bar aesthetics
+    if isempty(Gadfly.undefined_aesthetics(aes, element_aesthetics(xerrorbar())...))
+        xform = render(xerrorbar(), theme, aes)
+    else
+        xform = empty_form
+    end
+    if isempty(Gadfly.undefined_aesthetics(aes, element_aesthetics(yerrorbar())...))
+        yform = render(yerrorbar(), theme, aes)
+    else
+        yform = empty_form
+    end
+    xform | yform
+end
+
+function render(geom::YErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     Gadfly.assert_aesthetics_defined("Geom.errorbar", aes,
                                      element_aesthetics(geom)...)
     Gadfly.assert_aesthetics_equal_length("Geom.errorbar", aes,
@@ -56,4 +86,37 @@ function render(geom::ErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthet
                       for c in aes.color]))
 end
 
+function render(geom::XErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
+    Gadfly.assert_aesthetics_defined("Geom.errorbar", aes,
+                                     element_aesthetics(geom)...)
+    Gadfly.assert_aesthetics_equal_length("Geom.errorbar", aes,
+                                          element_aesthetics(geom)...)
 
+    default_aes = Gadfly.Aesthetics()
+    default_aes.color = PooledDataArray(ColorValue[theme.default_color])
+    aes = inherit(aes, default_aes)
+
+    # What are the actual extents. We can'n use 1/6
+    caplen = theme.errorbar_cap_length/2
+
+    compose(
+        combine(
+            # left cap
+            lines([[(xmin, y*cy - caplen), (xmin, y*cy + caplen)]
+                   for (xmin, y) in zip(aes.xmin, aes.y)]...),
+
+            # error bar
+            lines([[(xmin, y*cy), (xmax, y*cy)]
+                   for (xmin, xmax, y) in zip(aes.xmin, aes.xmax, aes.y)]...),
+
+            # right cap
+            lines([[(xmax, y*cy - caplen), (xmax, y*cy + caplen)]
+                   for (xmax, y) in zip(aes.xmax, aes.y)]...)),
+
+        stroke([theme.highlight_color(c) for c in aes.color]),
+        linewidth(theme.line_width),
+        aes.color_key_continuous == true ?
+            svgclass("geometry") :
+            svgclass([@sprintf("geometry color_%s", escape_id(aes.color_label(c)))
+                      for c in aes.color]))
+end


### PR DESCRIPTION
Geom.errorbar will now produce X and/or Y errorbars if the corresponding
aesthetics are defined. i.e. if xmin and xmax are given, then x errorbars are
drawn, and similarly for ymin and ymax.
