### PR TITLE
Fixed warnings for functions min and max.

### DIFF
--- a/src/geom/bar.jl
+++ b/src/geom/bar.jl
@@ -127,7 +127,7 @@ function render(geom::BarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
         aes2.xmax = Array(Float64, length(aes.x))
 
         span = length(aes.x) > 1 ?
-            (max(aes.x) - min(aes.x)) / (length(Set(aes.x...)) - 1) : 1.0
+            (maximum(aes.x) - minimum(aes.x)) / (length(Set(aes.x...)) - 1) : 1.0
         for (i, x) in enumerate(aes.x)
             aes2.xmin[i] = x - span/2
             aes2.xmax[i] = x + span/2

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -432,8 +432,8 @@ function apply_statistic(stat::TickStatistic,
         else
             grids = (ticks - 0.5)[2:end]
         end
-        viewmin = min(ticks)
-        viewmax = max(ticks)
+        viewmin = minimum(ticks)
+        viewmax = maximum(ticks)
     else
         minval, maxval = promote(minval, maxval)
         ticks, viewmin, viewmax =


### PR DESCRIPTION
Hello,

I noticed some warnings while using Gadfly. It seems that min and max functions are deprecated and we should use minimum and maximum instead. This commit fixes the warnings. Does it seem good to you ?

Bests.
