### PR TITLE
Clean up documentation, error message

### DIFF
--- a/doc/geom_bar.md
+++ b/doc/geom_bar.md
@@ -43,7 +43,7 @@ Gadfly.set_default_plot_size(12cm, 8cm)
 ```
 
 ```julia
-plot(data("HistData", "ChestSizes"), x="chest", y="count", Geom.bar)
+plot(data("HistData", "ChestSizes"), x="Chest", y="Count", Geom.bar)
 ```
 
 

--- a/doc/geom_boxplot.md
+++ b/doc/geom_boxplot.md
@@ -41,7 +41,7 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 ```
 
 ```julia
-plot(data("lattice", "singer"), x="voice.part", y="height", Geom.boxplot)
+plot(data("lattice", "singer"), x="VoicePart", y="Height", Geom.boxplot)
 ```
 
 

--- a/doc/geom_density.md
+++ b/doc/geom_density.md
@@ -23,9 +23,9 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 ```
 
 ```julia
-plot(data("ggplot2", "diamonds"), x="price", Geom.density)
+plot(data("ggplot2", "diamonds"), x="Price", Geom.density)
 ```
 
 ```julia
-plot(data("ggplot2", "diamonds"), x="price", color="cut", Geom.density)
+plot(data("ggplot2", "diamonds"), x="Price", color="Cut", Geom.density)
 ```

--- a/doc/geom_histogram.md
+++ b/doc/geom_histogram.md
@@ -34,17 +34,17 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 ```
 
 ```julia
-plot(data("ggplot2", "diamonds"), x="price", Geom.histogram)
+plot(data("ggplot2", "diamonds"), x="Price", Geom.histogram)
 ```
 
 ```julia
 # Binding categorical data to color
-plot(data("ggplot2", "diamonds"), x="price", color="cut", Geom.histogram)
+plot(data("ggplot2", "diamonds"), x="Price", color="Cut", Geom.histogram)
 ```
 
 ```julia
 # Choosing a smaller bin count
-plot(data("ggplot2", "diamonds"), x="price", color="cut",
+plot(data("ggplot2", "diamonds"), x="Price", color="Cut",
      Geom.histogram(bincount=30))
 ```
 

--- a/doc/geom_histogram2d.md
+++ b/doc/geom_histogram2d.md
@@ -41,17 +41,17 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 
 
 ```julia
-plot(data("car", "Womenlf"), x="hincome", y="region", Geom.histogram2d)
+plot(data("car", "Womenlf"), x="HIncome", y="Region", Geom.histogram2d)
 ```
 
 ```julia
-plot(data("car", "UN"), x="gdp", y="infant.mortality",
+plot(data("car", "UN"), x="GDP", y="InfantMortality",
      Scale.x_log10, Scale.y_log10, Geom.histogram2d)
 ```
 
 ```julia
 # Explicitly setting the number of bins
-plot(data("car", "UN"), x="gdp", y="infant.mortality",
+plot(data("car", "UN"), x="GDP", y="InfantMortality",
      Scale.x_log10, Scale.y_log10, Geom.histogram2d(xbincount=30, ybincount=30))
 ```
 

--- a/doc/geom_hline.md
+++ b/doc/geom_hline.md
@@ -27,14 +27,14 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 ```
 
 ```julia
-plot(data("datasets", "iris"), x="Sepal.Length", y="Sepal.Width",
+plot(data("datasets", "iris"), x="SepalLength", y="SepalWidth",
 	 yintercept=[2.5, 4.0], Geom.point, Geom.hline)
 ```
 
 ```julia
 # Colors and widths of lines can be changed. This works separately from the
 # `color` and `size` aesthetics.
-plot(data("datasets", "iris"), x="Sepal.Length", y="Sepal.Width",
+plot(data("datasets", "iris"), x="SepalLength", y="SepalWidth",
 	 yintercept=[2.5, 4.0], Geom.point,
 	 Geom.hline(color="orange", size=2mm))
 ```

--- a/doc/geom_label.md
+++ b/doc/geom_label.md
@@ -39,12 +39,12 @@ Gadfly.set_default_plot_size(14cm, 10cm)
 
 
 ```julia
-plot(data("ggplot2", "mpg"), x="cty", y="hwy", label="model", Geom.point, Geom.label)
+plot(data("ggplot2", "mpg"), x="Cty", y="Hwy", label="Model", Geom.point, Geom.label)
 ```
 
 
 ```julia
-plot(data("MASS", "mammals"), x="body", y="brain", label=1,
+plot(data("MASS", "mammals"), x="Body", y="Brain", label=1,
      Scale.x_log10, Scale.y_log10, Geom.point, Geom.label)
 ```
 

--- a/doc/geom_line.md
+++ b/doc/geom_line.md
@@ -31,10 +31,10 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 ```
 
 ```julia
-plot(data("lattice", "melanoma"), x="year", y="incidence", Geom.line)
+plot(data("lattice", "melanoma"), x="Year", y="Incidence", Geom.line)
 ```
 
 ```julia
-plot(data("Zelig", "approval"), x="month",  y="approve", color="year", Geom.line)
+plot(data("Zelig", "approval"), x="Month",  y="Approve", color="Year", Geom.line)
 ```
 

--- a/doc/geom_point.md
+++ b/doc/geom_point.md
@@ -24,24 +24,24 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 ```
 
 ```julia
-plot(data("datasets", "iris"), x="Sepal.Length", y="Sepal.Width", Geom.point)
+plot(data("datasets", "iris"), x="SepalLength", y="SepalWidth", Geom.point)
 ```
 
 ```julia
 # Binding categorial data to the color aesthetic
-plot(data("datasets", "iris"), x="Sepal.Length", y="Sepal.Width",
+plot(data("datasets", "iris"), x="SepalLength", y="SepalWidth",
      color="Species", Geom.point)
 ```
 
 ```julia
 # Binding continuous data to the color aesthetic
-plot(data("datasets", "iris"), x="Sepal.Length", y="Sepal.Width",
+plot(data("datasets", "iris"), x="SepalLength", y="SepalWidth",
      color="Petal.Length", Geom.point)
 ```
 
 ```julia
 # Binding categorial data to x
-plot(data("lattice", "singer"), x="voice.part", y="height", Geom.point)
+plot(data("lattice", "singer"), x="VoicePart", y="Height", Geom.point)
 ```
 
 <!-- TODO: shape aesthetic -->

--- a/doc/geom_rectbin.md
+++ b/doc/geom_rectbin.md
@@ -42,6 +42,6 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 
 
 ```julia
-plot(data("Zelig", "macro"), x="year", y="country", color="gdp", Geom.rectbin)
+plot(data("Zelig", "macro"), x="Year", y="Country", color="GDP", Geom.rectbin)
 ```
 

--- a/doc/geom_smooth.md
+++ b/doc/geom_smooth.md
@@ -31,5 +31,5 @@ Gadfly.set_default_plot_size(16cm, 10cm)
 ```
 
 ```julia
-plot(data("Zelig", "macro"), x="year", y="unem", color="country", Geom.point, Geom.smooth)
+plot(data("Zelig", "macro"), x="Year", y="Unem", color="Country", Geom.point, Geom.smooth)
 ```

--- a/doc/geom_subplot_grid.md
+++ b/doc/geom_subplot_grid.md
@@ -44,14 +44,14 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 ```julia
 set_default_plot_size(20cm, 7.5cm)
 plot(data("datasets", "OrchardSprays"),
-     xgroup="treatment", x="colpos", y="rowpos", color="decrease",
+     xgroup="Treatment", x="ColPos", y="RowPos", color="Decrease",
      Geom.subplot_grid(Geom.point))
 ```
 
 
 ```julia
 set_default_plot_size(14cm, 25cm)
-plot(data("vcd", "Suicide"), xgroup="sex", ygroup="method", x="age", y="Freq",
+plot(data("vcd", "Suicide"), xgroup="Sex", ygroup="Method", x="Age", y="Freq",
      Geom.subplot_grid(Geom.bar))
 ```
 

--- a/doc/geom_vline.md
+++ b/doc/geom_vline.md
@@ -27,14 +27,14 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 ```
 
 ```julia
-plot(data("datasets", "iris"), x="Sepal.Length", y="Sepal.Width",
+plot(data("datasets", "iris"), x="SepalLength", y="SepalWidth",
 	 xintercept=[5.0, 7.0], Geom.point, Geom.vline)
 ```
 
 ```julia
 # Colors and widths of lines can be changed. This works separately from the
 # `color` and `size` aesthetics.
-plot(data("datasets", "iris"), x="Sepal.Length", y="Sepal.Width",
+plot(data("datasets", "iris"), x="SepalLength", y="SepalWidth",
 	 xintercept=[5.0, 7.0], Geom.point,
 	 Geom.vline(color="orange", size=2mm))
 ```

--- a/doc/index.md
+++ b/doc/index.md
@@ -96,7 +96,7 @@ plot(x=1:10, y=2.^rand(10),
 ```
 
 To generate an image file from a plot, use the `draw` function. Gadfly supports
-a number of drawing backends. Each is used in similarly.
+a number of drawing backends. Each is used similarly.
 
 ```{.julia execute="false"}
 # define a plot
@@ -139,12 +139,12 @@ using RDatasets
 
 ```julia
 # E.g.
-plot(data("datasets", "iris"), x="Sepal.Length", y="Sepal.Width", Geom.point)
+plot(data("datasets", "iris"), x="SepalLength", y="SepalWidth", Geom.point)
 ```
 
 ```julia
 # E.g.
-plot(data("car", "SLID"), x="wages", color="language", Geom.histogram)
+plot(data("car", "SLID"), x="Wages", color="Language", Geom.histogram)
 ```
 
 Along with less typing, using data frames to generate plots allows the axis and
@@ -188,7 +188,7 @@ plot(layer(x=rand(10), y=rand(10), Geom.point),
 ```
 
 
-Or if you're data is in a DataFrame:
+Or if your data is in a DataFrame:
 
 ```{.julia execute="false"}
 plot(my_data, layer(x="some_column1", y="some_column2", Geom.point),
@@ -214,7 +214,7 @@ draw(PNG("myplot.png", 12cm, 6cm), p)
 
 ## Using the d3 backend
 
-The `D3` backend writes javascript. Making use of it's output is slightly more
+The `D3` backend writes javascript. Making use of its output is slightly more
 involved than with the image backends.
 
 Rendering to Javascript is easy enough:
@@ -230,7 +230,7 @@ src directory (which you can find by running `joinpath(Pkg.dir("Gadfly"), "src",
 
 D3 can be downloaded from [here](http://d3js.org/d3.v3.zip).
 
-Now the output can be included in an HTML like.
+Now the output can be included in an HTML page like:
 
 ```{.html execute="false"}
 <script src="d3.min.js"></script>

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -140,7 +140,7 @@ end
 
 
 function add_plot_element{T<:Element}(lyr::Layer, arg::T)
-    error("Layers can be used with elements of type $(typeof(arg))")
+    error("Layers can't be used with elements of type $(typeof(arg))")
 end
 
 


### PR DESCRIPTION
1) Gadfly.jl had an error message that you can’t use global elements
inside a layer, but the error message said “can” instead of “can’t”

2) Fixed all the RDatasets example changes where dots and lower case
letters were switched

3) Made minor grammar and spelling changes to index.md
