### PR TITLE
fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_install:
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.init(); Pkg.add("Cairo"); Pkg.add("RDatasets"); run(`ln -s $(pwd()) $(Pkg.dir("Gadfly"))`); Pkg.pin("Gadfly"); Pkg.resolve()'
-    - julia ~/.julia/Gadfly/tests/test.jl
+    - julia tests/test.jl


### PR DESCRIPTION
Fix the travis config due to recent change in default package directory. 

Still doesn't successfully pass the tests, but at least now they attempt to run. 
