### PR TITLE
enable travis tests with julia-releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,13 @@ compiler:
     - clang
 notifications:
     email: false
+env:
+    matrix: 
+        - JULIAVERSION="juliareleases" 
+        - JULIAVERSION="julianightlies" 
 before_install:
     - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-    - sudo add-apt-repository ppa:staticfloat/julianightlies -y
+    - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
     - sudo apt-get update -qq -y
     - sudo apt-get install git libpcre3-dev julia -y
 script:


### PR DESCRIPTION
Now that the tests actually pass on travis, it is time to check if they also work with julia-releases on travis. 
