### PR TITLE
documenting color scales

### DIFF
--- a/doc/scale_ContinuousColorScale.md
+++ b/doc/scale_ContinuousColorScale.md
@@ -1,0 +1,51 @@
+---
+title: ContinuousColorScale
+author: David Chudzicki
+part: Scale
+order: 2006
+...
+
+Create a continuous color scale to be used for the plot.
+
+# Arguments
+
+  * `f`: A function defined on the interval from 0 to 1 that returns a ```:ColorValue``` (as from the ```Color``` package).
+  * `minvalue` (optional): the data value corresponding to the bottom of the color scale (will be based on the range of the data if not specified)
+  * `maxvalue` (optional): the data value corresponding to the top of the color scale (will be based on the range of the data if not specified)
+
+# Aesthetics Acted On
+
+`color`
+
+# Examples
+
+```{.julia hide="true" results="none"}
+using Gadfly
+
+Gadfly.prepare_display()
+```
+
+Define a custom color scale for a grid:
+
+```julia
+using Color
+x = repeat([1:10], inner=[10])
+y = repeat([1:10], outer=[10])
+plot(x=x,y=y,color=x+y, Geom.rectbin, Scale.ContinuousColorScale(p -> RGB(0,p,0)))
+```
+
+Or we can use ```lab_gradient``` to construct a color gradient between 2 or more colors:
+
+```julia
+plot(x=x,y=y,color=x+y, Geom.rectbin, 
+     Scale.ContinuousColorScale(Scale.lab_gradient(color("green"), 
+                                                   color("white"), 
+                                                   color("red"))))
+```
+
+We can also start the color scale somewhere other than the bottom of the data range using ```minvalue```:
+
+```julia
+plot(x=x,y=y,color=x+y, Geom.rectbin, 
+     Scale.ContinuousColorScale(p -> RGB(0,p,0), minvalue=-20))
+```

--- a/doc/scale_continuous_color_gradient.md
+++ b/doc/scale_continuous_color_gradient.md
@@ -1,0 +1,37 @@
+---
+title: continuous_color_gradient
+author: David Chudzicki
+part: Scale
+order: 2008
+...
+
+Create a continuous color scale that the plot will use.
+
+# Arguments
+
+  * `minvalue` (optional): the data value corresponding to the bottom of the color scale (will be based on the range of the data if not specified).
+  * `maxvalue` (optional): the data value corresponding to the bottom of the color scale (will be based on the range of the data if not specified).
+
+# Variations
+
+```continuous_color``` and ```continuous_color_gradient``` are two names for the same thing.
+
+# Aesthetics Acted On
+
+`color`
+
+# Examples
+
+```{.julia hide="true" results="none"}
+using Gadfly
+
+Gadfly.prepare_display()
+srand(1234)
+```
+
+```julia
+# The data are all between 0 and 1, but the color scale goes from -1 to 1. 
+# For example, you might do this to force a consistent color scale between plots.
+plot(x=rand(12), y=rand(12), color=rand(12), 
+     Scale.continuous_color(minvalue=-1, maxvalue=1))
+```

--- a/doc/scale_discrete_color_hue.md
+++ b/doc/scale_discrete_color_hue.md
@@ -1,0 +1,33 @@
+---
+title: discrete_color_hue
+author: David Chudzicki
+part: Scale
+order: 2008
+...
+
+Create a discrete color scale to be used for the plot.
+
+# Arguments
+
+  * `levels` (optional): 
+  * `order` (optional): 
+
+# Variations 
+
+```discrete_color``` and ```discrete_color_hue``` are names for the same thing.
+
+# Examples
+
+```{.julia hide="true" results="none"}
+using Gadfly
+
+Gadfly.prepare_display()
+srand(1234)
+```
+
+This forces the use of a discrete scale on data that would otherwise receive a continuous scale:
+
+```julia
+plot(x=rand(12), y=rand(12), color=repeat([1,2,3], outer=[4]), 
+     Scale.discrete_color())
+```

--- a/doc/scale_discrete_color_manual.md
+++ b/doc/scale_discrete_color_manual.md
@@ -1,0 +1,32 @@
+---
+title: discrete_color_manual
+author: David Chudzicki
+part: Scale
+order: 2008
+...
+
+Create a discrete color scale to be used for the plot.
+
+# Arguments
+
+  * `colors...`: an iterable collection of things that can be converted to colors with ```Color.color``` (such as strings naming colors)
+  * `levels` (optional): 
+  * `order` (optional): 
+
+# Aesthetics Acted On
+
+`color`
+
+# Examples
+
+```{.julia hide="true" results="none"}
+using Gadfly
+
+Gadfly.prepare_display()
+srand(1234)
+```
+
+```julia
+plot(x=rand(12), y=rand(12), color=repeat(["a","b","c"], outer=[4]), 
+     Scale.discrete_color_manual("red","purple","green"))
+```


### PR DESCRIPTION
- I didn't document `DiscreteColorScale` because I couldn't think of a case I'd want to use it for rather than the other color scale constructors 
- my example plot for `discrete_color_hue` came out weirdly tall -- that happened with `judo Gadfly --package` but I think not when running ``judo` on just the one file, or generating the plot by any other means. I'm not sure what happened.
- I opened a couple issues that came up while doing this
