### PR TITLE
add opacity aesthetics

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -809,6 +809,7 @@ const default_aes_scales = {
                        :xgroup     => Scale.xgroup(),
                        :ygroup     => Scale.ygroup(),
                        :color      => Scale.continuous_color(),
+                       :opacity    => Scale.opacity_continuous(),
                        :label      => Scale.label(),
                        :size       => Scale.size_continuous()},
         :categorical => {:x          => Scale.x_discrete(),

--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -15,6 +15,7 @@ typealias NumericalAesthetic
     y,            NumericalOrCategoricalAesthetic
     size,         Maybe(Vector{Measure})
     color,        Maybe(AbstractDataVector{ColorValue})
+    opacity,      NumericalAesthetic
     label,        CategoricalAesthetic
 
     xmin,         NumericalAesthetic
@@ -79,6 +80,7 @@ end
 # Alternate aesthetic names
 const aesthetic_aliases =
     [:colour        => :color,
+     :alpha         => :opacity,
      :x_min         => :xmin,
      :x_max         => :xmax,
      :y_min         => :ymin,

--- a/src/data.jl
+++ b/src/data.jl
@@ -24,6 +24,7 @@
     xsize
     ysize
     color
+    opacity
     label
     titles, Dict{Symbol, String}, Dict{Symbol, String}()
 end

--- a/src/geom/point.jl
+++ b/src/geom/point.jl
@@ -8,7 +8,7 @@ const point = PointGeometry
 
 
 function element_aesthetics(::PointGeometry)
-    [:x, :y, :size, :color]
+    [:x, :y, :size, :color, :opacity]
 end
 
 
@@ -29,6 +29,7 @@ function render(geom::PointGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
 
     default_aes = Gadfly.Aesthetics()
     default_aes.color = PooledDataArray(ColorValue[theme.default_color])
+    default_aes.opacity = Float64[theme.default_point_opacity]
     default_aes.size = Measure[theme.default_point_size]
     aes = inherit(aes, default_aes)
 
@@ -36,6 +37,7 @@ function render(geom::PointGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
     lw_ratio = theme.line_width / aes.size[1]
     compose(circle(aes.x, aes.y, aes.size),
             fill(aes.color),
+            opacity(aes.opacity),
             stroke([theme.highlight_color(c) for c in aes.color]),
             linewidth(theme.line_width),
             d3embed(@sprintf(".on(\"mouseover\", geom_point_mouseover(%0.2f, %0.2f), false)",

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -169,6 +169,7 @@ const x_sqrt       = continuous_scale_partial(x_vars, sqrt_transform)
 const y_sqrt       = continuous_scale_partial(y_vars, sqrt_transform)
 
 const size_continuous = continuous_scale_partial([:size], identity_transform)
+const opacity_continuous = continuous_scale_partial([:opacity], identity_transform)
 
 
 function element_aesthetics(scale::ContinuousScale)

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -29,6 +29,9 @@ end
     # is used.
     default_color,         ColorOrNothing,  LCHab(70, 60, 240)
 
+    # Default point opacity when the opacity aesthetic is not mapped.
+    default_point_opacity, Float64,         1.0
+
     # Default size when the size aesthetic is not mapped.
     default_point_size,    Measure,         0.6mm
 


### PR DESCRIPTION
I have not found alpha/opacity aesthetics in Gadfly. This patch should provide it (general definitions and Geom.Point implementation). In order for the patch to work, Compose.jl should be updated as well with another pull request (dcjones/Compose.jl/pull/45).