### PR TITLE
documented preserve_order in Geom.line

### DIFF
--- a/doc/geom_line.md
+++ b/doc/geom_line.md
@@ -11,8 +11,6 @@ order: 1007
   * `x`: X-axis position.
   * `y`: Y-axis position.
   * `color` (optional): Group categorically by color.
-  * `preserve_order` (optional): If `false` (default), data points on the line are connected in the order determined by `x`. If `true`, they trace out a path in the order in which they are given.	
-
 
 # Arguments
 


### PR DESCRIPTION
I didn't realize this was possible at first. I'll probably use it for drawing geographic outlines.

FWIW, I was looking for this initially as `Geom.path`. I wonder if we want a `Geom.path()` that just creates a `Geom.LineGeometry` with `preserve_order=true`? If you think so, I could make a PR adding that.
