### PR TITLE
Fix color assignment in 2D Histogram (Fix #310)

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -392,7 +392,7 @@ function apply_statistic(stat::Histogram2DStatistic,
     data = Gadfly.Data()
     data.color = Array(Int, n)
     k = 1
-    for cnt in bincounts
+    for cnt in transpose(bincounts)
         if cnt > 0
             data.color[k] = cnt
             k += 1
@@ -925,4 +925,3 @@ end
 
 
 end # module Stat
-


### PR DESCRIPTION
I think color information in the 2D histogram is being stored in row-major order, while the bincounts are stored in column-major order.  

```
xdat = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1]
ydat = [0, 0, 0, 2, 2, 2, 4, 4, 4, 2]
plot(x=xdat,y=ydat, Geom.histogram2d(xbincount=5, ybincount=5))
```

Gives the following
![672a6d8](https://cloud.githubusercontent.com/assets/7328215/3183177/293a3e50-ec64-11e3-8566-0752e3c12dd7.png)
as opposed to
![transposed](https://cloud.githubusercontent.com/assets/7328215/3183184/40cef6d2-ec64-11e3-822a-d1ddfc6f0ed9.png)

This might not be the best way to fix this, but transposing bincounts before assigning the color values seems to work. So 

```
plot(x=randn(100000),y=randn(100000), Geom.histogram2d(xbincount=100,ybincoun
t=100))
```

Now correctly shows

![transposed-2d-gaussian](https://cloud.githubusercontent.com/assets/7328215/3183187/5b4adf58-ec64-11e3-8e32-b6d0617c6a4d.png)
