### PR TITLE
Fix contour line ordering issue from #293

### DIFF
--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -16,7 +16,7 @@ end
 const line = LineGeometry
 
 
-function contour(; n=15, samples=150, preserve_order=false)
+function contour(; n=15, samples=150, preserve_order=true)
     return LineGeometry(Gadfly.Stat.contour(n=n, samples=samples),
                                             preserve_order=preserve_order)
 end


### PR DESCRIPTION
I think the problem is with the `preserve_order` property being set to false.  Making it `true` by default seems to fix it.
![contour](https://cloud.githubusercontent.com/assets/7328215/3483789/101b571c-0396-11e4-885a-85afdfd7740a.png)
