### PR TITLE
RFC: Contour plotting from a matrix

### DIFF
--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -1,13 +1,13 @@
 
 
 typealias NumericalOrCategoricalAesthetic
-    Union(Nothing, Vector, DataArray, PooledDataArray)
+    Union(Nothing, Matrix, Vector, DataArray, PooledDataArray)
 
 typealias CategoricalAesthetic
     Union(Nothing, PooledDataArray)
 
 typealias NumericalAesthetic
-    Union(Nothing, Vector, DataArray)
+    Union(Nothing, Matrix, Vector, DataArray)
 
 
 @varset Aesthetics begin
@@ -107,7 +107,8 @@ const aesthetic_aliases =
      :x_tick        => :xtick,
      :y_tick        => :ytick,
      :x_grid        => :xgrid,
-     :y_grid        => :ygrid]
+     :y_grid        => :ygrid,
+     :z             => :func]
 
 
 # Index as if this were a data frame

--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -18,8 +18,8 @@ end
 const line = LineGeometry
 
 
-function contour(; n=15, samples=150, preserve_order=true)
-    return LineGeometry(Gadfly.Stat.contour(n=n, samples=samples),
+function contour(; levels=15, samples=150, preserve_order=true)
+    return LineGeometry(Gadfly.Stat.contour(levels=levels, samples=samples),
                                             preserve_order=preserve_order)
 end
 


### PR DESCRIPTION
This adds the ability to plot contours from a matrix (#293).  Here are some usage examples:
http://nbviewer.ipython.org/gist/darwindarak/1ae4a7a7539695e1dd38/

There are a few parts of the implementation that I'm not too comfortable with, since I don't know how it
would interact with the existing code.  I added a `Matrix` type to the `NumericalOrCategoricalAesthetic` type alias so that the `func` aesthetic could be used to store the matrix.  Would it make more sense if I added a new `z`  aesthetic instead?

**Breaking Change**:

I replaced the `n` field in `ContourStatistic` with `levels` so that it represents either the number of levels or an array of levels.   The default function contour plotting should remain unchanged though.
