### PR TITLE
add support for multi-geom layers

### DIFF
--- a/tests/multi_geom_layer.jl
+++ b/tests/multi_geom_layer.jl
@@ -1,0 +1,4 @@
+using Gadfly
+
+plot(layer(Geom.line, x=1:10, y=1:10, Theme(default_color=color("red"))),
+     layer(Geom.point, Geom.label, x=[5], y=[5], label=["5"]))

--- a/tests/test.jl
+++ b/tests/test.jl
@@ -77,6 +77,7 @@ tests = [
     ("stat_qq",                               6inch, 16inch),
     ("line_histogram",                        6inch, 3inch),
     ("layer_data",                            6inch, 3inch),
+    ("multi_geom_layer",                      6inch, 3inch),
 
 ]
 


### PR DESCRIPTION
This is done by making the `layer()` function return a `Vector{Layer}`.

All the `add_plot_element(::Layer, element)` methods are replaced with equivalent `add_plot_element(::Vector{Layer}, element)` which broadcasts the element to each Layer. The exception is when adding a geom, in which case a copy of the last layer in the vector is added with the requested geom.

That is, `layer()` returns a vector of layers, which are all identical except for their geoms.  `plot()` now accepts a `Vector{Layer}` as a valid element type, appending it to the internal vector of layers.

Fixes #317
