### PR TITLE
Fix bounds for Date plotting in years

### DIFF
--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -184,7 +184,7 @@ function optimize_ticks(x_min::Date, x_max::Date; extend_ticks::Bool=false,
         end
     else
         ticks, viewmin, viewmax =
-            optimize_ticks(year(x_min), year(x_max), extend_ticks=extend_ticks)
+            optimize_ticks(year(x_min), year(x_max + Year(1) - Day(1)), extend_ticks=extend_ticks)
         return Date[Date(iround(y)) for y in ticks],
                    Date(iround(viewmin)), Date(iround(viewmax))
     end


### PR DESCRIPTION
When plotting Dates in years, Gadfly previously chose x_max as the year of the maximum date.  This would truncate any data points that are in the most recent year after January 1.

This patch changes it to be the year of the maximum date plus a year less a day, retaining the current behavior for dates that fall exactly on January one, and choosing better bounds for all other dates.
