### PR TITLE
Add encoding info to HTML header. Fix #492

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -906,7 +906,10 @@ function display(d::REPLDisplay, ::MIME"text/html", p::Plot)
         """
         <!DOCTYPE html>
         <html>
-          <head><title>Gadfly Plot</title></head>
+          <head>
+            <title>Gadfly Plot</title>
+            <meta charset="utf-8">
+          </head>
             <body>
             <script charset="utf-8">
                 $(readall(Compose.snapsvgjs))


### PR DESCRIPTION
This fixes an encoding problem when plotting from the REPL.
