### PR TITLE
WIP: Add tolerance for equality when optimizing ticks (Fix #550)

### DIFF
--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -65,7 +65,7 @@ end
 function optimize_ticks_typed{T}(x_min::T, x_max::T, extend_ticks, Q::Vector{(Float64,Float64)}, k_min,
                            k_max, k_ideal, strict_span)
     one_t = one(T)
-    if x_min == x_max
+    if x_max - x_min < eps()*one_t
         R = typeof(1.0 * one_t)
         return R[x_min], x_min - one_t, x_min + one_t
     end


### PR DESCRIPTION
The main problem is in the [computation](https://github.com/dcjones/Gadfly.jl/blob/404f0aa433fa5431ba377234bd6d3427e9c174ab/src/ticks.jl#L93)

```julia
r = ceil((x_max - span) / (q*10.0^z * one_t))
```

where `z` is basically `log10(x_max - x_min)`.  If `x_max - x_min` is very small, `r` becomes too large.  Using `eps()` as the tolerance just happens to fix the failing example listed in #550, it is still too low for other examples.  For example:

```julia
y = ones(5)
y[1] = 1 + 2eps()

plot(x = 1:5, y = y, Geom.point)
```

will result in an infinite [loop](https://github.com/dcjones/Gadfly.jl/blob/404f0aa433fa5431ba377234bd6d3427e9c174ab/src/ticks.jl#L94)

@dcjones, any thoughts on how we can pick a reasonable tolerance?