### PR TITLE
Maximum number columns in key (legend) as a Theme parameter

### DIFF
--- a/doc/themes.md
+++ b/doc/themes.md
@@ -46,6 +46,7 @@ overrides the default theme's value.
   * `key_label_font`: Font used for key entry labels. (String)
   * `key_label_font_size`: Font size used for key entry labels. (Measure)
   * `key_label_color`: Color used for key entry labels. (ColorValue)
+  * `key_max_columns`: Maximum number of columns for key entry labels. (Int)
   * `bar_spacing`: Spacing between bars in `Geom.bar`. (Measure)
   * `boxplot_spacing`: Spacing between boxplots in `Geom.boxplot`. (Measure)
   * `errorbar_cap_length`: Length of caps on error bars. (Measure)

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -190,7 +190,7 @@ function render_discrete_color_key(colors::Vector{ColorValue},
                                    theme::Gadfly.Theme)
 
     # only consider layouts with a reasonable number of columns
-    maxcols = 4
+    maxcols = theme.key_max_columns < 1 ? 1 : theme.key_max_columns
 
     n = length(colors)
 

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -187,6 +187,9 @@ end
     # Probability of proposing a visibility flip during label layout.
     label_visibility_flip_pr,    Float64,   0.2
 
+    # Number of columns in key
+    key_max_columns,             Int,       4
+
 end
 
 


### PR DESCRIPTION
Sometimes, I need more columns in legend then 4, especially when legend is positioned horizontally.

Here is an example of the legend with a default setting of 4 columns:
<img src="https://cloud.githubusercontent.com/assets/38350/7106493/981fb2b8-e110-11e4-8825-7855396987c2.png" alt="key4" width="350"/>

And the same plot with a maximum column number set to 12:
<img src="https://cloud.githubusercontent.com/assets/38350/7106518/5bc7af72-e111-11e4-9903-8226aebcb1f7.png" alt="key12" width="350"/>