### PR TITLE
Add documentation  Guide attributes in multi-layer plot

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -202,6 +202,15 @@ plot(layer(x=rand(10), y=rand(10), Geom.point, order=1),
      layer(x=rand(10), y=rand(10), Geom.line, order=2))
 ```
 
+Guide attributes may be added to a multi-layer plot:
+```.{julia execute="false"}
+plt=plot( [ layer(x=rand(10), y=rand(10), Geom.point),
+            layer(x=rand(10), y=rand(10), Geom.line)  ],
+            Guide.XLabel("XLabel"), 
+            Guide.YLabel("YLabel"),
+            Guide.Title("Title")
+         );
+```
 
 # Stacking
 

--- a/test/layer_guide.jl
+++ b/test/layer_guide.jl
@@ -1,0 +1,10 @@
+
+using Gadfly
+
+plot(layer(x=[1,2,3], y=[4,5,6], Theme(default_color=color("red")), Geom.point),
+     layer(x=[4,5,6], y=[1,2,3], Theme(default_color=color("blue")), Geom.point),
+     Guide.XLabel("XLabel"), 
+     Guide.YLabel("YLabel"),
+     Guide.Title("Title")
+     )
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,7 @@ tests = [
     ("issue120",                              6inch, 3inch),
     ("histogram2d_discrete",                  6inch, 3inch),
     ("layer_themes",                          6inch, 3inch),
+    ("layer_guide",                           6inch, 3inch),
     ("discrete_color_manual",                 6inch, 3inch),
     ("ordered_line",                          6inch, 3inch),
     ("nan_skipping",                          6inch, 3inch),


### PR DESCRIPTION
Hi @dcjones 

This PR adds documentation for using Guide attributes (e.g. title) in a multi-layer plot. 

*It seems necessary to update the documentation in view of misleading information on various websites* like: 
http://stackoverflow.com/questions/21721344/how-to-add-legend-in-a-graph-when-using-package-gadfly-jl-in-julia