### PR TITLE
Fix for 1st Geom.line datapoint not being concrete

### DIFF
--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -174,7 +174,7 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
                 continue
             end
 
-            if i > 1 && c != points_colors[end]
+            if isempty(points_colors) || c != points_colors[end]
                 first_point = true
             end
 


### PR DESCRIPTION
In such case the points_colors array would still be empty, although i>1