### PR TITLE
Switch to convert(Array, ...) from array(...)

### DIFF
--- a/doc/guide_colorkey.md
+++ b/doc/guide_colorkey.md
@@ -20,6 +20,6 @@ Gadfly.set_default_plot_size(14cm, 8cm)
 ```
 
 ```julia
-volcano = float(array(dataset("datasets", "volcano")))
+volcano = float(convert(Array, dataset("datasets", "volcano")))
 plot(z=volcano, Geom.contour, Guide.colorkey("Elevation"))
 ```


### PR DESCRIPTION
The latter throws a warning that array(df::AbstractDataFrame) is deprecated.