### PR TITLE
Create guide_manual_color_key.md

### DIFF
--- a/doc/guide_manual_color_key.md
+++ b/doc/guide_manual_color_key.md
@@ -1,0 +1,32 @@
+---
+title: manual_color_key
+author: Alex Ryckman Mellnik
+part: Guide
+order: 3006
+...
+
+Manually define a color key
+
+# Arguments
+  * `title`: Legend title
+  * `labels`: Item labels
+  * `colors`: Item colors
+
+# Examples
+
+Combine two layers into a plot, and set a custom color of one layer.  Add a manual color key with labels that match the two layers.  (Note that "deepskyblue" is the default color for Geom.line and others.)
+
+```{.julia hide="true" results="none"}
+using Gadfly
+using DataFrames
+
+Gadfly.set_default_plot_size(14cm, 8cm)
+```
+
+```julia
+points = DataFrame(index=rand(0:10,30), val=rand(1:10,30))
+line = DataFrame(val=rand(1:10,11), index = [0:10])
+pointLayer = layer(points, x="index", y="val", Geom.point,Theme(default_color=color("green")))
+lineLayer = layer(line, x="index", y="val", Geom.line)
+plot(pointLayer, lineLayer, Guide.manual_color_key("Legend", ["Points", "Line"], ["green", "deepskyblue"]))
+```


### PR DESCRIPTION
Add a guide for Guide.manual_color_key since there wasn't already one.  I also snuck two handy things into the example which are not easily found in the guide:  modifying the color of an individual layer and what the name of the default "Gadfly blue" color is.  I'm not sure about the metadata at the top, the order might need to be changed.