### PR TITLE
WIP: Document rendering process

### DIFF
--- a/doc/dev_pipeline.md
+++ b/doc/dev_pipeline.md
@@ -1,0 +1,93 @@
+---
+title: Rendering Pipeline
+author: Darwin Darakananda
+part: Gadfly Internals
+order: 3001
+...
+
+```{.julia hide="true"}
+using DataFrames
+using Color
+using Compose
+using RDatasets
+using Showoff
+using Gadfly
+```
+
+How does the function call
+
+```{.julia execute="false"}
+df = dataset("ggplot2", "diamonds")
+p = plot(df,
+         x = :Price, color = :Cut,
+		 Stat.histogram,
+		 Geom.bar)
+```
+
+actually get turned into following plot?
+
+```{.julia hide="true"}
+df = dataset("ggplot2", "diamonds")
+p = plot(df,
+         x = :Price, color = :Cut,
+		 Stat.histogram,
+		 Geom.bar)
+p_rendered = deepcopy(p)
+```
+
+## The 10,000-foot View
+
+The rendering pipeline transforms a plot specification into a [Compose](http://www.composejl.org) scene graph that contains a set of guides (e.g. axis ticks, color keys) and one or more layers of geometry (e.g. points, lines).
+The specification of each layer has
+
+- a **data source** (e.g. `dataset("ggplot2", "diamonds")`)
+- a **geometry** to represent the layer's data (e.g. point, line, etc.)
+- **mappings** to associate aesthetics of the geometry with elements of the data source (e.g.  `:color => :Cut`)
+- layer-wise **statistics** (optional) to be applied to the layer's data 
+
+All layers of the a plot share the same
+
+- **coordinate system** for the geometry (e.g. cartesian, polar, etc.)
+- axis **scales** (e.g. loglog, semilog, etc.)
+- plot-wise **statistics** (optional) to be applied to all layers
+- **guides**
+
+A full plot specification must describe these shared elements as well as all the layer specifications.
+In the example above, we see that only the data source, statistics, geometry, and mapping are specified.
+The missing elements are either infered from the data (e.g. categorical values in `df[:Cut]` implies a discrete color scale), or assumed using defaults (e.g. continuous x-axis scale).
+For example, invoking `plot` with all the elements will look something like
+
+```{.julia execute="false"}
+p = plot(layer(df,
+               x = :Price, color = :Cut,
+		       Stat.histogram,
+		       Geom.bar),
+	  	 Scale.x_continuous,
+		 Scale.color_discrete,
+		 Coord.cartesian,
+		 Guide.xticks, Guide.yticks,
+		 Guide.xlabel("Price"),
+		 Guide.colorkey("Cut"))
+```
+
+Once a full plot specification is filled out, the rendering process proceeds as follows:
+
+<img style="position: relative; width: 110%" src="pipeline.svg"/>
+
+1. For each layer in the plot, we first map subsets of the data source to a `Data` object. The `Price` and `Cut` columns of the `diamond` dataset are mapped to the `:x` and `:color` fields of `Data`, respectively.
+
+2. Scales are applied to the data to obtain plottable aesthetics. `Scale.x_continuous` keeps the values of `df[:Price]` unchanged, while `Scale.color_discrete` maps the unique elements of `df[:Cut]` (an array of strings) to actual color values.
+
+3. The aesthetics are transformed by layer-wise and plot-wise statistics, in order. `Stat.histogram` replaces the `x` field of the aesthetics with bin positions, and sets the `y` field with the corresponding counts.
+
+4. Using the position aesthetics from all layers, we create a Compose context with a coordinate system that fits the data to screen coordinates. `Coord.cartesian` creates a Compose context that maps a vertical distance of `3000` counts to about two inches in the rendered plot.
+
+5. Each layer renders its own geometry.
+
+6. Finally, we compute the layout of the guides and render them on top of the plot context.
+
+## More Detailed Walkthrough
+### Data Source to Aesthetics
+### Aesthetics to Geometry
+### Rendering Geometry
+### Guide Layout

--- a/doc/dev_pipeline.md
+++ b/doc/dev_pipeline.md
@@ -45,7 +45,7 @@ The specification of each layer has
 - **mappings** to associate aesthetics of the geometry with elements of the data source (e.g.  `:color => :Cut`)
 - layer-wise **statistics** (optional) to be applied to the layer's data 
 
-All layers of the a plot share the same
+All layers of a plot share the same
 
 - **coordinate system** for the geometry (e.g. cartesian, polar, etc.)
 - axis **scales** (e.g. loglog, semilog, etc.)
@@ -54,7 +54,7 @@ All layers of the a plot share the same
 
 A full plot specification must describe these shared elements as well as all the layer specifications.
 In the example above, we see that only the data source, statistics, geometry, and mapping are specified.
-The missing elements are either infered from the data (e.g. categorical values in `df[:Cut]` implies a discrete color scale), or assumed using defaults (e.g. continuous x-axis scale).
+The missing elements are either inferred from the data (e.g. categorical values in `df[:Cut]` implies a discrete color scale), or assumed using defaults (e.g. continuous x-axis scale).
 For example, invoking `plot` with all the elements will look something like
 
 ```{.julia execute="false"}

--- a/doc/pipeline.svg
+++ b/doc/pipeline.svg
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="1089px" height="1068px" viewBox="0 0 1090 1068" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.3.2 (12043) - http://www.bohemiancoding.com/sketch -->
+    <title>pipeline</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-1">
+            <feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.35 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
+                <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+        </filter>
+        <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-2">
+            <feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.35 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
+                <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+        </filter>
+        <filter x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox" id="filter-3">
+            <feOffset dx="0" dy="2" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.35 0" in="shadowBlurOuter1" type="matrix" result="shadowMatrixOuter1"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
+                <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+        </filter>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <rect id="Background" fill="#282828" sketch:type="MSShapeGroup" x="0" y="0" width="1090" height="1068"></rect>
+        <text id="Rendering-Pipeline" fill="#F4E6D7" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="48" font-weight="normal">
+            <tspan x="363" y="80">Rendering Pipeline</tspan>
+        </text>
+        <g id="Plot-Stats" sketch:type="MSLayerGroup" transform="translate(48.000000, 699.000000)">
+            <rect id="Plot-Stats-Background" fill="#FD6C6C" sketch:type="MSShapeGroup" x="0" y="0" width="92" height="43"></rect>
+            <text fill="#F4E6D7" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="26" font-weight="normal">
+                <tspan x="18" y="31">Stats</tspan>
+            </text>
+        </g>
+        <g id="Coords" sketch:type="MSLayerGroup" transform="translate(48.000000, 770.000000)">
+            <rect id="Coord-Background" fill="#FD6C6C" sketch:type="MSShapeGroup" x="0" y="0" width="92" height="43"></rect>
+            <text id="Coord" fill="#F4E6D7" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="26" font-weight="normal">
+                <tspan x="12" y="31">Coord</tspan>
+            </text>
+        </g>
+        <g id="Scale" sketch:type="MSLayerGroup" transform="translate(48.000000, 454.000000)">
+            <rect id="Scale-Background" fill="#FD6C6C" sketch:type="MSShapeGroup" x="0" y="0" width="92" height="43"></rect>
+            <text fill="#F4E6D7" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="26" font-weight="normal">
+                <tspan x="16" y="31">Scale</tspan>
+            </text>
+        </g>
+        <g id="Guide" sketch:type="MSLayerGroup" transform="translate(48.000000, 940.000000)">
+            <rect id="Guide-Background" fill="#20C5BF" sketch:type="MSShapeGroup" x="0" y="0" width="92" height="43"></rect>
+            <text fill="#F4E6D7" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="26" font-weight="normal">
+                <tspan x="14" y="31">Guide</tspan>
+            </text>
+        </g>
+        <g id="Layer-Pipeline" sketch:type="MSLayerGroup" transform="translate(149.000000, 124.000000)">
+            <rect id="Layer-3" fill="#F4E6D7" filter="url(#filter-1)" sketch:type="MSShapeGroup" x="93" y="24" width="824" height="884"></rect>
+            <rect id="Layer-2" fill="#F4E6D7" filter="url(#filter-2)" sketch:type="MSShapeGroup" x="81" y="12" width="824" height="884"></rect>
+            <rect id="Layer-1" fill="#F4E6D7" filter="url(#filter-3)" sketch:type="MSShapeGroup" x="69" y="0" width="824" height="884"></rect>
+            <g id="Data" transform="translate(436.000000, 240.000000)">
+                <rect id="Data-Background" fill="#FD6C6C" sketch:type="MSShapeGroup" x="0" y="0" width="77" height="43"></rect>
+                <text fill="#F4E6D7" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="26" font-weight="normal">
+                    <tspan x="13" y="31">Data</tspan>
+                </text>
+            </g>
+            <g id="Data-Source" transform="translate(397.000000, 57.000000)">
+                <rect id="Data-Source-Background" fill="#FD6C6C" sketch:type="MSShapeGroup" x="0" y="0" width="156" height="43"></rect>
+                <text fill="#F4E6D7" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="26" font-weight="normal">
+                    <tspan x="12" y="31">Data Source</tspan>
+                </text>
+            </g>
+            <g id="Geom" transform="translate(430.000000, 817.000000)">
+                <rect id="Geom-Background" fill="#20C5BF" sketch:type="MSShapeGroup" x="0" y="0" width="92" height="43"></rect>
+                <text fill="#F4E6D7" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="26" font-weight="normal">
+                    <tspan x="13" y="31">Geom</tspan>
+                </text>
+            </g>
+            <g id="Aesthetics" transform="translate(397.000000, 423.000000)">
+                <rect id="Aesthetics-Background" fill="#FD6C6C" sketch:type="MSShapeGroup" x="0" y="0" width="156" height="43"></rect>
+                <text fill="#F4E6D7" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="26" font-weight="normal">
+                    <tspan x="22" y="31">Aesthetics</tspan>
+                </text>
+            </g>
+            <g id="Mapping" transform="translate(713.000000, 146.000000)">
+                <rect id="Mapping-Background" fill="#FD6C6C" sketch:type="MSShapeGroup" x="0" y="0" width="156" height="43"></rect>
+                <text fill="#F4E6D7" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="26" font-weight="normal">
+                    <tspan x="31" y="31">Mapping</tspan>
+                </text>
+            </g>
+            <g id="Layer-Stats" transform="translate(713.000000, 507.000000)">
+                <rect id="Layer-Stats-Background" fill="#FD6C6C" sketch:type="MSShapeGroup" x="0" y="0" width="92" height="43"></rect>
+                <text fill="#F4E6D7" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="26" font-weight="normal">
+                    <tspan x="18" y="31">Stats</tspan>
+                </text>
+            </g>
+            <g id="Transforming-aesthetics" transform="translate(467.000000, 468.000000)" sketch:type="MSShapeGroup">
+                <path d="M8,0 L8,331" id="Line" stroke="#282828" stroke-width="4" stroke-linecap="square"></path>
+                <path d="M0,333 L16,333 L8,349 L0,333 Z" id="Path-14-Copy" fill="#282828"></path>
+            </g>
+            <text id="Evaluate-mapping" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="24" font-weight="normal" fill="#282828">
+                <tspan x="513" y="154">Evaluate mapping</tspan>
+            </text>
+            <g id="Apply-plot-scales" transform="translate(1.000000, 285.000000)">
+                <path d="M474,0 L474,120" id="Line" stroke="#282828" stroke-width="4" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+                <ellipse id="Oval-1-Copy-4" stroke="#282828" stroke-width="4" fill="#F4E6D7" sketch:type="MSShapeGroup" cx="474" cy="65" rx="10" ry="10"></ellipse>
+                <text sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="24" font-weight="normal" fill="#282828">
+                    <tspan x="149.5" y="48">Apply plot scales</tspan>
+                </text>
+                <path d="M35,65 L453.5,65" id="Line" stroke="#282828" stroke-width="4" stroke-linecap="square" stroke-dasharray="10" sketch:type="MSShapeGroup"></path>
+                <path d="M0,65 L71,65" id="Line-Copy-4" stroke="#F4E6D7" stroke-width="4" stroke-linecap="square" stroke-dasharray="10" sketch:type="MSShapeGroup"></path>
+                <path d="M466,122 L482,122 L474,138 L466,122 Z" id="Path-14-Copy" fill="#282828" sketch:type="MSShapeGroup"></path>
+            </g>
+            <g id="Apply-plot-statistics" transform="translate(0.000000, 557.000000)">
+                <circle id="Oval-1-Copy-3" stroke="#282828" stroke-width="4" fill="#F4E6D7" sketch:type="MSShapeGroup" cx="475" cy="41" r="10"></circle>
+                <text id="Apply-plot-statistic" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="24" font-weight="normal" fill="#282828">
+                    <tspan x="136.5" y="24">Apply plot statistics</tspan>
+                </text>
+                <path d="M36,41 L454.5,41" id="Line-Copy" stroke="#282828" stroke-width="4" stroke-linecap="square" stroke-dasharray="10" sketch:type="MSShapeGroup"></path>
+                <path d="M0,40 L71,40" id="Line-Copy-7" stroke="#F4E6D7" stroke-width="4" stroke-linecap="square" stroke-dasharray="10" sketch:type="MSShapeGroup"></path>
+            </g>
+            <g id="Apply-layer-statistics" transform="translate(465.000000, 167.000000)">
+                <circle id="Oval-1" stroke="#282828" stroke-width="4" fill="#F4E6D7" sketch:type="MSShapeGroup" cx="10" cy="361" r="10"></circle>
+                <text id="Apply-layer-statisti" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="24" font-weight="normal" fill="#282828">
+                    <tspan x="30" y="344">Apply layer statistics</tspan>
+                </text>
+                <path d="M30,362 L241,362" id="Line-Copy-3" stroke="#282828" stroke-width="4" stroke-linecap="square" stroke-dasharray="10" sketch:type="MSShapeGroup"></path>
+                <path d="M25,1 L236,1" id="Line-Copy-9" stroke="#282828" stroke-width="4" stroke-linecap="square" stroke-dasharray="10" sketch:type="MSShapeGroup"></path>
+            </g>
+            <g id="Transform-to-plot-coordinates" transform="translate(0.000000, 627.000000)">
+                <circle id="Oval-1-Copy-2" stroke="#282828" stroke-width="4" fill="#F4E6D7" sketch:type="MSShapeGroup" cx="474.5" cy="41.5" r="10.5"></circle>
+                <text id="Transform-to-plot-co" sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="24" font-weight="normal" fill="#282828">
+                    <tspan x="99" y="24">Transform to plot coordinates</tspan>
+                </text>
+                <path d="M36,42 L454.5,42" id="Line-Copy-2" stroke="#282828" stroke-width="4" stroke-linecap="square" stroke-dasharray="10" sketch:type="MSShapeGroup"></path>
+                <path d="M0,41 L71,41" id="Line-Copy-8" stroke="#F4E6D7" stroke-width="4" stroke-linecap="square" stroke-dasharray="10" sketch:type="MSShapeGroup"></path>
+            </g>
+            <text sketch:type="MSTextLayer" font-family="Quire Sans, Source Sans Pro, sans-serif" font-size="40" font-weight="normal" fill="#282828">
+                <tspan x="175" y="129">Layer </tspan>
+                <tspan x="175" y="179">Pipeline</tspan>
+            </text>
+        </g>
+        <g id="Aesthetics-for-guides" sketch:type="MSLayerGroup" transform="translate(87.000000, 226.000000)">
+            <g id="Line-Copy-6-+-Oval-1-Copy-6-+-Path-14-Copy-2" transform="translate(527.000000, 0.000000)" sketch:type="MSShapeGroup">
+                <path d="M10,0 L10,120" id="Line-Copy-6" stroke="#282828" stroke-width="4" stroke-linecap="square"></path>
+                <ellipse id="Oval-1-Copy-6" stroke="#282828" stroke-width="4" fill="#F4E6D7" cx="10" cy="65" rx="10" ry="10"></ellipse>
+                <path d="M2,122 L18,122 L10,138 L2,122 Z" id="Path-14-Copy-2" fill="#282828"></path>
+            </g>
+            <path d="M533.5,636 L133,636" id="Line" stroke="#282828" stroke-width="4" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+            <path d="M129,636 L8,636" id="Line-Copy-5" stroke="#F4E6D7" stroke-width="4" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+            <path d="M8,636 L8,696" id="Line" stroke="#F4E6D7" stroke-width="4" stroke-linecap="square" sketch:type="MSShapeGroup"></path>
+            <circle id="Oval-1-Copy-5" stroke="#282828" stroke-width="4" fill="#282828" sketch:type="MSShapeGroup" cx="537" cy="636" r="5"></circle>
+            <path d="M0,698 L16,698 L8,714 L0,698 Z" id="Path-14-Copy" fill="#F4E6D7" sketch:type="MSShapeGroup"></path>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
This documents how a `plot` invocation gets turned into a Compose scene graph.  I'm hoping this will make it easier to refactor existing code, and encourage contributions to the code base (maybe even plugin packages).

The plan is to have a "10000-foot view" of the process, then a detailed function-by-function walkthrough.  I've only started on the overview section, and there are already many simplifications.  While many default are actually computed during the rendering process, the overview assumes that all the elements are already specified.

This is still a massive work in progress.  Any corrections/suggestions are welcome and appreciated.

@dcjones, do you mind checking for correctness?  Hopefully I haven't botched it too badly.