### PR TITLE
Allow x-axis with SIUnits

### DIFF
--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -4,7 +4,7 @@
 # little opaque because I want to avoid assuming the log function is defined
 # over typeof(xspan)
 function bounding_order_of_magnitude{DT}(xspan::DT)
-    one_dt = one(DT)
+    one_dt = convert(DT, one(DT))
 
     a = 1
     step = 1
@@ -71,7 +71,7 @@ function optimize_ticks_typed{T}(x_min::T, x_max::T, extend_ticks,
                            granularity_weight::Float64, simplicity_weight::Float64,
                            coverage_weight::Float64, niceness_weight::Float64,
                            strict_span)
-    one_t = one(T)
+    one_t = convert(T, one(T))
     if x_max - x_min < eps()*one_t
         R = typeof(1.0 * one_t)
         return R[x_min], x_min - one_t, x_min + one_t


### PR DESCRIPTION
Since https://github.com/Keno/SIUnits.jl/pull/34, `one(10Second)` has simply been returning `1` instead of `1s`.  While this is technically more correct as a multiplicative identity, it caused issues in comparisons and non-multiplicative maths. This changes usage of `one(T)` in determining x bounds and ticks to `convert(T, one(T))`, which more explicitly expresses what we want - a one of the same type.

There are probably more cases like this, but it's a start.  The very simple `plot(x=(0:.1:10)Second, y=sin(0:.1:10)Meter)` now works!