### PR TITLE
WIP: Improve time to first plot

### DIFF
--- a/src/guide.jl
+++ b/src/guide.jl
@@ -58,6 +58,7 @@ function render(guide::PanelBackground, theme::Gadfly.Theme,
 
     return [PositionedGuide([back], 0, under_guide_position)]
 end
+Base.precompile(render, (PanelBackground,Gadfly.Theme,Gadfly.Aesthetics))
 
 
 immutable ZoomSlider <: Gadfly.GuideElement
@@ -166,6 +167,7 @@ function render(guide::ZoomSlider, theme::Gadfly.Theme,
 
     return [PositionedGuide([root], 0, over_guide_position)]
 end
+Base.precompile(render, (ZoomSlider,Gadfly.Theme,Gadfly.Aesthetics))
 
 
 immutable ColorKey <: Gadfly.GuideElement
@@ -693,6 +695,7 @@ function render(guide::XTicks, theme::Gadfly.Theme,
                             bottom_guide_position),
             PositionedGuide([grid_lines], 0, under_guide_position)]
 end
+Base.precompile(render, (XTicks,Gadfly.Theme,Gadfly.Aesthetics))
 
 
 immutable YTicks <: Gadfly.GuideElement
@@ -862,6 +865,7 @@ function render(guide::YTicks, theme::Gadfly.Theme,
                             left_guide_position),
             PositionedGuide([grid_lines], 0, under_guide_position)]
 end
+Base.precompile(render, (YTicks,Gadfly.Theme,Gadfly.Aesthetics))
 
 
 # X-axis label Guide
@@ -927,6 +931,7 @@ function render(guide::XLabel, theme::Gadfly.Theme,
 
     return [PositionedGuide(contexts, 0, bottom_guide_position)]
 end
+Base.precompile(render, (XLabel,Gadfly.Theme,Gadfly.Aesthetics))
 
 
 # Y-axis label Guide
@@ -986,6 +991,7 @@ function render(guide::YLabel, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
 
     return [PositionedGuide(contexts, 0, left_guide_position)]
 end
+Base.precompile(render, (YLabel,Gadfly.Theme,Gadfly.Aesthetics))
 
 # Title Guide
 immutable Title <: Gadfly.GuideElement


### PR DESCRIPTION
I'll be updating this PR. I'm doing lots of experiments, but I'm trying to maximize impact for minimal change

---

### Before starting

```julia
tic(); using Gadfly; toc()
x = rand(10); y = rand(10)
@time draw(SVG("perftest.svg",4inch,3inch),plot(x=x,y=y,Geom.point))
#elapsed time: 2.387055702 seconds
#16.082651 seconds (25.50 M allocations: 1.155 GB, 2.19% gc time)
```

```julia
tic(); using Gadfly; toc()
x = rand(10); y = rand(10)
@time render(plot(x=x,y=y,Geom.point))
#elapsed time: 2.469379532 seconds
# 11.998200 seconds (20.47 M allocations: 963.208 MB, 2.56% gc time)
#elapsed time: 2.411486561 seconds
# 12.099843 seconds (20.46 M allocations: 963.552 MB, 2.58% gc time)
```

Focus on `render`