### PR TITLE
RFC: call plot and render once in module to precompile those routines

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -1159,4 +1159,11 @@ end
 const x_axis_label_aesthetics = [:x, :xmin, :xmax]
 const y_axis_label_aesthetics = [:y, :ymin, :ymax]
 
+let
+    x = 1:10; y = cumsum(randn(10));
+    p = plot(x=x, y=y, Geom.point, Geom.line)
+    render(p)
+    nothing
+end
+
 end # module Gadfly


### PR DESCRIPTION
Trying to speed things up.

On current master I get:

```
julia> tic(); using Gadfly; toc()
elapsed time: 3.452206278 seconds
3.452206278

julia> x = 1:10; y = cumsum(randn(10));

julia> gc_enable(false)
true

julia> @time render(plot(x=x,y=y,Geom.point));
 17.578433 seconds (20.63 M allocations: 973.109 MB)
```

With this PR:

```
julia> tic(); using Gadfly; toc()
elapsed time: 3.511360173 seconds
3.511360173

julia> x = 1:10; y = cumsum(randn(10));

julia> gc_enable(false)
true

julia> @time render(plot(x=x,y=y,Geom.point));
  7.876351 seconds (7.13 M allocations: 292.230 MB)
```

The disclaimer I offer here is that it takes much much longer to precompile Gadfly (something like 40 seconds instead of 20). For users this is a one time per update cost, so it would probably be worth it. For devs it is quite annoying to wait so long every time Gadfly is touched. We could get around that by just commenting out these lines while developing and enabling them again before updating master. Because that is more of a hassle for development I'm not sure that trade-off is worth it, hence the reason this is an RFC. 

If we do decide this is worthwhile we could probably add more `Geom`s or `Guide`s to what is `render`ed in the let block to get those things to be faster on the first call per session also.

Any thoughts?