### PR TITLE
Use sampling to improve speed in estimate of continuous/discrete binning

### DIFF
--- a/src/bincount.jl
+++ b/src/bincount.jl
@@ -92,14 +92,17 @@ function choose_bin_count_1d(xs::AbstractVector, d_min=1, d_max=150)
 
     # Brute force optimization: since the number of bins has to be reasonably
     # small to plot, this is pretty quick and very simple.
-    for d in d_min:d_max
-        binwidth = span / d
-        bin!(bincounts, xs, x_min, binwidth, d)
-        pll = bincount_pll(d, n, bincounts, binwidth)
+    d_best = d_min
+    if d_min < d_max
+        for d in d_min:d_max
+            binwidth = span / d
+            bin!(bincounts, xs, x_min, binwidth, d)
+            pll = bincount_pll(d, n, bincounts, binwidth)
 
-        if pll > pll_best
-            d_best = d
-            pll_best = pll
+            if pll > pll_best
+                d_best = d
+                pll_best = pll
+            end
         end
     end
 


### PR DESCRIPTION
For
```jl
p = Gadfly.plot(x=randn(10^6), Gadfly.Geom.histogram(bincount=100));
```

Master:
```jl
julia> @time render(p);
  1.911688 seconds (15.05 M allocations: 357.836 MB, 11.58% gc time)
```

This PR:
```jl
julia> @time render(p);
  0.215660 seconds (4.05 M allocations: 70.582 MB, 11.79% gc time)
```

There's still more than can be done, but I have to go on to other things now.

(Remaining bottleneck is in applying the scales due to `::Function` in `ContinuousScaleTransform`. How do you feel about FastAnonymous.jl?)