### PR TITLE
Add support for tags in Geom objects

### DIFF
--- a/src/geom/bar.jl
+++ b/src/geom/bar.jl
@@ -13,9 +13,13 @@ immutable BarGeometry <: Gadfly.GeometryElement
 
     default_statistic::Gadfly.StatisticElement
 
+    tag::Symbol
+
     function BarGeometry(default_statistic=Gadfly.Stat.identity();
-                         position::Symbol=:stack, orientation::Symbol=:vertical)
-        new(position, orientation, default_statistic)
+                         position::Symbol=:stack,
+                         orientation::Symbol=:vertical,
+                         tag::Symbol=empty_tag)
+        new(position, orientation, default_statistic, tag)
     end
 end
 
@@ -61,7 +65,7 @@ function render_colorless_bar(geom::BarGeometry,
                       [Measure(cy=ymin) + theme.bar_spacing/2 for ymin in aes.ymin],
                       abs(aes.x),
                       [Measure(cy=(ymax - ymin)) - theme.bar_spacing
-                       for (ymin, ymax) in zip(aes.ymin, aes.ymax)]),
+                       for (ymin, ymax) in zip(aes.ymin, aes.ymax)], geom.tag),
             svgclass("geometry"))
     else
         YT = eltype(aes.y)
@@ -72,7 +76,7 @@ function render_colorless_bar(geom::BarGeometry,
                       [min(yz, y) for y in aes.y],
                       [Measure(cx=(xmax - xmin)) - theme.bar_spacing
                        for (xmin, xmax) in zip(aes.xmin, aes.xmax)],
-                      abs(aes.y)),
+                      abs(aes.y), geom.tag),
             svgclass("geometry"))
     end
 
@@ -121,7 +125,7 @@ function render_colorful_stacked_bar(geom::BarGeometry,
                 stack_height,
                 [aes.ymin[i]*cy + theme.bar_spacing/2 for i in idxs],
                 [aes.x[i] for i in idxs],
-                [(aes.ymax[i] - aes.ymin[i])*cy - theme.bar_spacing for i in idxs]))
+                [(aes.ymax[i] - aes.ymin[i])*cy - theme.bar_spacing for i in idxs], geom.tag))
     elseif orientation == :vertical
         stack_height_dict = Dict()
         T = eltype(aes.y)
@@ -142,7 +146,7 @@ function render_colorful_stacked_bar(geom::BarGeometry,
                 [aes.xmin[i]*cx + theme.bar_spacing/2 for i in idxs],
                 stack_height,
                 [(aes.xmax[i] - aes.xmin[i])*cx - theme.bar_spacing for i in idxs],
-                [aes.y[i] for i in idxs]))
+                [aes.y[i] for i in idxs], geom.tag))
     else
         error("Orientation must be :horizontal or :vertical")
     end
@@ -204,7 +208,7 @@ function render_colorful_dodged_bar(geom::BarGeometry,
                 dodge_pos,
                 abs(aes_x),
                 [((aes.ymax[i] - aes.ymin[i])*cy - theme.bar_spacing) / dodge_count[aes.ymin[i]]
-                 for i in idxs]))
+                 for i in idxs], geom.tag))
     elseif orientation == :vertical
         dodge_count = DefaultDict(() -> 0)
         for i in idxs
@@ -236,7 +240,7 @@ function render_colorful_dodged_bar(geom::BarGeometry,
                 [min(yz, y) for y in aes_y],
                 [((aes.xmax[i] - aes.xmin[i])*cx - theme.bar_spacing) / dodge_count[aes.xmin[i]]
                  for i in idxs],
-                abs(aes_y)))
+                abs(aes_y), geom.tag))
     else
         error("Orientation must be :horizontal or :vertical")
     end
@@ -333,5 +337,3 @@ function render(geom::BarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
         linewidth(theme.highlight_width),
         svgattribute("shape-rendering", "crispEdges"))
 end
-
-

--- a/src/geom/beeswarm.jl
+++ b/src/geom/beeswarm.jl
@@ -4,9 +4,12 @@ immutable BeeswarmGeometry <: Gadfly.GeometryElement
     # :vertical or :horizontal
     orientation::Symbol
     padding::Measure
+    tag::Symbol
 
-    function BeeswarmGeometry(; orientation::Symbol=:vertical, padding::Measure=0.1mm)
-        new(orientation, padding)
+    function BeeswarmGeometry(; orientation::Symbol=:vertical,
+                                padding::Measure=0.1mm,
+                                tag::Symbol=empty_tag)
+        new(orientation, padding, tag)
     end
 end
 
@@ -138,9 +141,9 @@ function render(geom::BeeswarmGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthet
         end
 
         if geom.orientation == :horizontal
-            f = circle(val, positions, aes.size)
+            f = circle(val, positions, aes.size, geom.tag)
         else
-            f = circle(positions, val, aes.size)
+            f = circle(positions, val, aes.size, geom.tag)
         end
 
         return compose(context(), f, fill(aes.color),
@@ -149,5 +152,3 @@ function render(geom::BeeswarmGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthet
 
     return compose!(context(order=4), svgclass("geometry"), ctxp)
 end
-
-

--- a/src/geom/boxplot.jl
+++ b/src/geom/boxplot.jl
@@ -1,5 +1,10 @@
 
 immutable BoxplotGeometry <: Gadfly.GeometryElement
+    tag::Symbol
+
+    function BoxplotGeometry(; tag::Symbol=empty_tag)
+        new(tag)
+    end
 end
 
 
@@ -62,8 +67,12 @@ function render(geom::BoxplotGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
         end
     end
 
+    tbox, tlw, tuw, tlf, tuf, to, tm =
+        subtags(geom.tag, :box, :lower_whisker, :upper_whisker,
+                          :lower_fence, :upper_fence, :outliers, :middle)
+
     ctx = compose!(
-        context(),
+        context(tag=geom.tag),
         fill(collect(cs)),
         stroke(collect(cs)),
         linewidth(theme.line_width),
@@ -74,24 +83,24 @@ function render(geom::BoxplotGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
             rectangle(
                 [x - bw/2 for x in xs],
                 lower_hinge, [bw],
-                [uh - lh for (lh, uh) in zip(lower_hinge, upper_hinge)]),
+                [uh - lh for (lh, uh) in zip(lower_hinge, upper_hinge)], tbox),
 
             (
                 context(),
 
                  # Whiskers
                 Compose.line([[(x, lh), (x, lf)]
-                              for (x, lh, lf) in zip(xs, lower_hinge, lower_fence)]),
+                              for (x, lh, lf) in zip(xs, lower_hinge, lower_fence)], tlw),
 
                 Compose.line([[(x, uh), (x, uf)]
-                              for (x, uh, uf) in zip(xs, upper_hinge, upper_fence)]),
+                              for (x, uh, uf) in zip(xs, upper_hinge, upper_fence)], tuw),
 
                 # Fences
                 Compose.line([[(x - fw/2, lf), (x + fw/2, lf)]
-                              for (x, lf) in zip(xs, lower_fence)]),
+                              for (x, lf) in zip(xs, lower_fence)], tlf),
 
                 Compose.line([[(x - fw/2, uf), (x + fw/2, uf)]
-                              for (x, uf) in zip(xs, upper_fence)]),
+                              for (x, uf) in zip(xs, upper_fence)], tuf),
 
                 stroke(collect(cs))
             ),
@@ -107,7 +116,7 @@ function render(geom::BoxplotGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
             (context(),
              circle([x for (x, y, c) in xys],
                     [y for (x, y, c) in xys],
-                    [theme.default_point_size]),
+                    [theme.default_point_size], to),
              stroke([theme.discrete_highlight_color(c) for (x, y, c) in xys]),
              fill([c for (x, y, c) in xys])))
     end
@@ -117,7 +126,7 @@ function render(geom::BoxplotGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
         compose!(ctx, (
            context(order=1),
            Compose.line([[(x - fw/2, mid), (x + fw/2, mid)]
-                         for (x, mid) in zip(xs, aes.middle)]),
+                         for (x, mid) in zip(xs, aes.middle)], tm),
            linewidth(theme.middle_width),
            stroke([theme.middle_color(c) for c in cs])
         ))
@@ -125,5 +134,3 @@ function render(geom::BoxplotGeometry, theme::Gadfly.Theme, aes::Gadfly.Aestheti
 
     return ctx
 end
-
-

--- a/src/geom/errorbar.jl
+++ b/src/geom/errorbar.jl
@@ -1,11 +1,26 @@
 
 immutable ErrorBarGeometry <: Gadfly.GeometryElement
+    tag::Symbol
+
+    function ErrorBarGeometry(; tag::Symbol=empty_tag)
+        new(tag)
+    end
 end
 
 immutable XErrorBarGeometry <: Gadfly.GeometryElement
+    tag::Symbol
+
+    function XErrorBarGeometry(; tag::Symbol=empty_tag)
+        new(tag)
+    end
 end
 
 immutable YErrorBarGeometry <: Gadfly.GeometryElement
+    tag::Symbol
+
+    function YErrorBarGeometry(; tag::Symbol=empty_tag)
+        new(tag)
+    end
 end
 
 const errorbar = ErrorBarGeometry
@@ -61,21 +76,22 @@ function render(geom::YErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthe
     default_aes.color = PooledDataArray(RGB{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
     caplen = theme.errorbar_cap_length/2
+    ttc, teb, tbc = subtags(geom.tag, :top_cap, :error_bar, :bottom_cap)
 
     return compose!(
-        context(order=3),
+        context(order=3; tag=geom.tag),
 
         # top cap
         Compose.line([[(x*cx - caplen, ymax), (x*cx + caplen, ymax)]
-                      for (x, ymax) in zip(aes.x, aes.ymax)]),
+                      for (x, ymax) in zip(aes.x, aes.ymax)], ttc),
 
         # error bar
         Compose.line([[(x*cx, ymax), (x*cx, ymin)]
-                      for (x, ymin, ymax) in zip(aes.x, aes.ymin, aes.ymax)]),
+                      for (x, ymin, ymax) in zip(aes.x, aes.ymin, aes.ymax)], teb),
 
         # bottom cap
         Compose.line([[(x*cx - caplen, ymin), (x*cx + caplen, ymin)]
-                      for (x, ymin) in zip(aes.x, aes.ymin)]),
+                      for (x, ymin) in zip(aes.x, aes.ymin)], tbc),
 
         stroke([theme.stroke_color(c) for c in aes.color]),
         linewidth(theme.line_width),
@@ -96,21 +112,22 @@ function render(geom::XErrorBarGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthe
     default_aes.color = PooledDataArray(RGB{Float32}[theme.default_color])
     aes = inherit(aes, default_aes)
     caplen = theme.errorbar_cap_length/2
+    tlc, teb, trc = subtags(geom.tag, :left_cap, :error_bar, :right_cap)
 
     return compose!(
-        context(order=3),
+        context(order=3, tag=geom.tag),
 
-        # top cap
+        # left cap
         Compose.line([[(xmin, y*cy - caplen), (xmin, y*cy + caplen)]
-                      for (xmin, y) in zip(aes.xmin, aes.y)]),
+                      for (xmin, y) in zip(aes.xmin, aes.y)], tlc),
 
         # error bar
         Compose.line([[(xmin, y*cy), (xmax, y*cy)]
-                      for (xmin, xmax, y) in zip(aes.xmin, aes.xmax, aes.y)]),
+                      for (xmin, xmax, y) in zip(aes.xmin, aes.xmax, aes.y)], teb),
 
         # right cap
         Compose.line([[(xmax, y*cy - caplen), (xmax, y*cy + caplen)]
-                      for (xmax, y) in zip(aes.xmax, aes.y)]),
+                      for (xmax, y) in zip(aes.xmax, aes.y)], trc),
 
         stroke([theme.stroke_color(c) for c in aes.color]),
         linewidth(theme.line_width),

--- a/src/geom/hexbin.jl
+++ b/src/geom/hexbin.jl
@@ -3,14 +3,16 @@ using Hexagons
 
 immutable HexagonalBinGeometry <: Gadfly.GeometryElement
     default_statistic::Gadfly.StatisticElement
+    tag::Symbol
 
     function HexagonalBinGeometry(
-            default_statistic::Gadfly.StatisticElement=Gadfly.Stat.identity())
-        new(default_statistic)
+            default_statistic::Gadfly.StatisticElement=Gadfly.Stat.identity();
+            tag::Symbol=empty_tag)
+        new(default_statistic, tag)
     end
 
-    function HexagonalBinGeometry(; xbincount=200, ybincount=200)
-        new(Gadfly.Stat.hexbin(xbincount=xbincount, ybincount=ybincount))
+    function HexagonalBinGeometry(; xbincount=200, ybincount=200, tag::Symbol=empty_tag)
+        new(Gadfly.Stat.hexbin(xbincount=xbincount, ybincount=ybincount), tag)
     end
 end
 
@@ -49,11 +51,9 @@ function render(geom::HexagonalBinGeometry, theme::Gadfly.Theme, aes::Gadfly.Aes
 
     return compose!(
         context(),
-        Compose.polygon([hexpoints(xs[i], ys[i], xsizes[i], ysizes[i]) for i in 1:n]),
+        Compose.polygon([hexpoints(xs[i], ys[i], xsizes[i], ysizes[i]) for i in 1:n], geom.tag),
         linewidth(0.1mm), # pad the hexagons so they ovelap a little
         fill(cs),
         stroke(cs),
         svgclass("geometry"))
 end
-
-

--- a/src/geom/hline.jl
+++ b/src/geom/hline.jl
@@ -2,11 +2,13 @@
 immutable HLineGeometry <: Gadfly.GeometryElement
     color::Union(Color, Nothing)
     size::Union(Measure, Nothing)
+    tag::Symbol
 
     function HLineGeometry(; color=nothing,
-                           size::Union(Measure, Nothing)=nothing)
+                           size::Union(Measure, Nothing)=nothing,
+                           tag::Symbol=empty_tag)
         new(color === nothing ? nothing : Colors.color(color),
-            size)
+            size, tag)
     end
 end
 
@@ -27,9 +29,8 @@ function render(geom::HLineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
 
     return compose!(
         context(),
-        Compose.line([[(0w, y), (1w, y)] for y in aes.yintercept]),
+        Compose.line([[(0w, y), (1w, y)] for y in aes.yintercept], geom.tag),
         stroke(color),
         linewidth(size),
         svgclass("xfixed"))
 end
-

--- a/src/geom/label.jl
+++ b/src/geom/label.jl
@@ -7,8 +7,10 @@ immutable LabelGeometry <: Gadfly.GeometryElement
     # lael layout.
     hide_overlaps::Bool
 
-    function LabelGeometry(;position=:dynamic, hide_overlaps::Bool=true)
-        new(position, hide_overlaps)
+    tag::Symbol
+
+    function LabelGeometry(;position=:dynamic, hide_overlaps::Bool=true, tag::Symbol=empty_tag)
+        new(position, hide_overlaps, tag)
     end
 end
 
@@ -253,7 +255,7 @@ function deferred_label_context(geom::LabelGeometry,
         text([(positions[i].x0 + extents[i][1].abs/2)*mm for i in 1:n],
              [(positions[i].y0 + extents[i][2].abs/2)*mm for i in 1:n],
              aes.label,
-             [hcenter], [vcenter]),
+             [hcenter], [vcenter]; tag=geom.tag),
         visible(label_visibility),
         font(theme.point_label_font),
         fontsize(theme.point_label_font_size),
@@ -292,7 +294,7 @@ function render(geom::LabelGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
             text([Compose.x_measure(x) + xoff for x in aes.x],
                  [Compose.y_measure(y) + yoff for y in aes.y],
                  aes.label,
-                 [hpos], [vpos]),
+                 [hpos], [vpos]; tag=geom.tag),
             font(theme.point_label_font),
             fontsize(theme.point_label_font_size),
             fill(theme.point_label_color),
@@ -300,6 +302,3 @@ function render(geom::LabelGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
             svgclass("geometry"))
     end
 end
-
-
-

--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -8,9 +8,11 @@ immutable LineGeometry <: Gadfly.GeometryElement
 
     order::Int
 
+    tag::Symbol
+
     function LineGeometry(default_statistic=Gadfly.Stat.identity();
-                          preserve_order=false, order=2)
-        new(default_statistic, preserve_order, order)
+                          preserve_order=false, order=2, tag=empty_tag)
+        new(default_statistic, preserve_order, order, tag)
     end
 end
 
@@ -131,7 +133,7 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
         classes = [string("geometry ", svg_color_class_from_label(aes.color_label([c])[1]))
                    for (c, g) in zip(points_colors, points_groups)]
 
-        ctx = compose!(ctx, Compose.line(points),
+        ctx = compose!(ctx, Compose.line(points,geom.tag),
                       stroke(points_colors),
                       svgclass(classes))
 
@@ -143,7 +145,7 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
             sort!(points, by=first)
         end
 
-        ctx = compose!(ctx, Compose.line(points),
+        ctx = compose!(ctx, Compose.line(points,geom.tag),
                        stroke(aes.color[1]),
                        svgclass("geometry"))
     else
@@ -190,12 +192,10 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
         classes = [string("geometry ", svg_color_class_from_label(aes.color_label([c])[1]))
                    for c in points_colors]
 
-        ctx = compose!(ctx, Compose.line(points),
+        ctx = compose!(ctx, Compose.line(points,geom.tag),
                       stroke(points_colors),
                       svgclass(classes))
     end
 
     return compose!(ctx, fill(nothing), linewidth(theme.line_width))
 end
-
-

--- a/src/geom/point.jl
+++ b/src/geom/point.jl
@@ -1,6 +1,11 @@
 
 # Geometry which displays points at given (x, y) positions.
 immutable PointGeometry <: Gadfly.GeometryElement
+    tag::Symbol
+
+    function PointGeometry(; tag::Symbol=empty_tag)
+        new(tag)
+    end
 end
 
 
@@ -39,7 +44,7 @@ function render(geom::PointGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
 
     ctx = compose!(
         context(),
-        circle(aes.x, aes.y, aes.size),
+        circle(aes.x, aes.y, aes.size, geom.tag),
         fill(aes.color),
         linewidth(theme.highlight_width))
 
@@ -55,5 +60,3 @@ function render(geom::PointGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
 
     return compose!(context(order=4), svgclass("geometry"), ctx)
 end
-
-

--- a/src/geom/polygon.jl
+++ b/src/geom/polygon.jl
@@ -3,10 +3,12 @@ immutable PolygonGeometry <: Gadfly.GeometryElement
     order::Int
     fill::Bool
     preserve_order::Bool
+    tag::Symbol
 
     function PolygonGeometry(; order::Int=0, fill::Bool=false,
-                               preserve_order::Bool=false)
-        return new(order, fill, preserve_order)
+                               preserve_order::Bool=false,
+                               tag::Symbol=empty_tag)
+        return new(order, fill, preserve_order, tag)
     end
 end
 
@@ -55,7 +57,7 @@ function render(geom::PolygonGeometry, theme::Gadfly.Theme,
 
         compose!(ctx,
             Compose.polygon([polygon_points(xs[(c,g)], ys[(c,g)], geom.preserve_order)
-                             for (c,g) in keys(xs)]))
+                             for (c,g) in keys(xs)], geom.tag))
         cs = [c for (c,g) in keys(xs)]
         if geom.fill
             compose!(ctx, fill(cs),
@@ -65,7 +67,7 @@ function render(geom::PolygonGeometry, theme::Gadfly.Theme,
         end
     elseif length(aes.color) == 1 &&
             !(isa(aes.color, PooledDataArray) && length(levels(aes.color)) > 1)
-        compose!(ctx, Compose.polygon(polygon_points(aes.x, aes.y, geom.preserve_order)))
+        compose!(ctx, Compose.polygon(polygon_points(aes.x, aes.y, geom.preserve_order), geom.tag))
         if geom.fill
             compose!(ctx, fill(aes.color[1]),
                      stroke(theme.discrete_highlight_color(aes.color[1])))
@@ -84,7 +86,7 @@ function render(geom::PolygonGeometry, theme::Gadfly.Theme,
 
         compose!(ctx,
             Compose.polygon([polygon_points(xs[c], ys[c], geom.preserve_order)
-                             for c in keys(xs)]))
+                             for c in keys(xs)], geom.tag))
         cs = collect(keys(xs))
         if geom.fill
             compose!(ctx, fill(cs),
@@ -96,4 +98,3 @@ function render(geom::PolygonGeometry, theme::Gadfly.Theme,
 
     return compose!(ctx, linewidth(theme.line_width), svgclass("geometry"))
 end
-

--- a/src/geom/rectbin.jl
+++ b/src/geom/rectbin.jl
@@ -1,10 +1,12 @@
 
 immutable RectangularBinGeometry <: Gadfly.GeometryElement
     default_statistic::Gadfly.StatisticElement
+    tag::Symbol
 
     function RectangularBinGeometry(
-            default_statistic::Gadfly.StatisticElement=Gadfly.Stat.identity())
-        new(default_statistic)
+            default_statistic::Gadfly.StatisticElement=Gadfly.Stat.identity();
+            tag::Symbol=empty_tag)
+        new(default_statistic, tag)
     end
 end
 
@@ -121,11 +123,9 @@ function render(geom::RectangularBinGeometry, theme::Gadfly.Theme, aes::Gadfly.A
 
     return compose!(
         context(),
-        rectangle(xmin, ymin, xwidths, ywidths),
+        rectangle(xmin, ymin, xwidths, ywidths, geom.tag),
         fill(cs),
         stroke(nothing),
         svgclass("geometry"),
         svgattribute("shape-rendering", "crispEdges"))
 end
-
-

--- a/src/geom/ribbon.jl
+++ b/src/geom/ribbon.jl
@@ -1,9 +1,11 @@
 
 immutable RibbonGeometry <: Gadfly.GeometryElement
     default_statistic::Gadfly.StatisticElement
+    tag::Symbol
 
-    function RibbonGeometry(default_statistic=Gadfly.Stat.identity())
-        new(default_statistic)
+    function RibbonGeometry(default_statistic=Gadfly.Stat.identity();
+                            tag::Symbol=empty_tag)
+        new(default_statistic, tag)
     end
 end
 
@@ -69,7 +71,7 @@ function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
         ctx = compose!(
             context(),
             Compose.polygon([collect((@compat Tuple{XT, YT}), chain(min_points[c], max_points[c]))
-                     for c in keys(max_points)]),
+                     for c in keys(max_points)], geom.tag),
             fill([theme.lowlight_color(c) for c in keys(max_points)]))
     end
 
@@ -79,4 +81,3 @@ function render(geom::RibbonGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
         stroke(nothing),
         linewidth(theme.line_width))
 end
-

--- a/src/geom/violin.jl
+++ b/src/geom/violin.jl
@@ -1,9 +1,10 @@
 
 immutable ViolinGeometry <: Gadfly.GeometryElement
     order::Int
+    tag::Symbol
 
-    function ViolinGeometry(; order=1)
-        new(order)
+    function ViolinGeometry(; order=1, tag::Symbol=empty_tag)
+        new(order, tag)
     end
 end
 
@@ -40,7 +41,7 @@ function render(geom::ViolinGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetic
     compose!(ctx,
              Compose.polygon([vcat([(x - w/2, y) for (y, w) in zip(grouped_y[x], grouped_width[x])],
                                    reverse!([(x + w/2, y) for (y, w) in zip(grouped_y[x], grouped_width[x])]))
-                              for x in keys(grouped_y)]))
+                              for x in keys(grouped_y)], geom.tag))
 
 
     return compose!(ctx,

--- a/src/geom/vline.jl
+++ b/src/geom/vline.jl
@@ -2,10 +2,12 @@
 immutable VLineGeometry <: Gadfly.GeometryElement
     color::Union(Color, Nothing)
     size::Union(Measure, Nothing)
+    tag::Symbol
 
     function VLineGeometry(; color=nothing,
-                           size::Union(Measure, Nothing)=nothing)
-        new(color === nothing ? nothing : Colors.color(color), size)
+                           size::Union(Measure, Nothing)=nothing,
+                           tag::Symbol=empty_tag)
+        new(color === nothing ? nothing : Colors.color(color), size, tag)
     end
 end
 
@@ -26,7 +28,7 @@ function render(geom::VLineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
 
     return compose!(
         context(),
-        Compose.line([[(x, 0h), (x, 1h)] for x in aes.xintercept]),
+        Compose.line([[(x, 0h), (x, 1h)] for x in aes.xintercept], geom.tag),
         stroke(color),
         linewidth(size),
         svgclass("yfixed"))

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -16,6 +16,15 @@ import Gadfly: render, layers, element_aesthetics, inherit, escape_id,
 import Iterators
 import Iterators: cycle, product, distinct, takestrict, chain, repeated
 
+const empty_tag = symbol("")
+
+function subtags(parent_tag, suffixes...)
+    if parent_tag == empty_tag
+        return map(s->empty_tag, suffixes)
+    end
+    return map(s->symbol(string(parent_tag, "#", s)), suffixes)
+end
+
 
 # Geometry that renders nothing.
 immutable Nil <: Gadfly.GeometryElement
@@ -62,4 +71,3 @@ include("geom/polygon.jl")
 include("geom/beeswarm.jl")
 
 end # module Geom
-


### PR DESCRIPTION
This allows users to "name" particular graphical elements. These names get inserted into the rendered Compose tree, which allows us to find them again later. See also https://github.com/dcjones/Compose.jl/pull/148.

Simple objects (points, lines, circles, etc) put the tag in the Form. "Grouped" objects (errorbars, boxpolots, etc) put the tag into the Context, and annotate each Form element with a derived untypable name.
