### PR TITLE
Insert more entry points into render

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -434,7 +434,7 @@ end
 # Returns:
 #   A compose Canvas containing the graphic.
 #
-function render(plot::Plot)
+function render_prepare(plot::Plot)
     if isempty(plot.layers)
         layer = Layer()
         layer.geom = Geom.point()
@@ -772,6 +772,16 @@ function render(plot::Plot)
         end
     end
 
+    return (plot, coord, plot_aes,
+            layer_aess, layer_stats, layer_subplot_aess, layer_subplot_datas,
+            scales, guides)
+end
+
+function render(plot::Plot)
+    (plot, coord, plot_aes,
+     layer_aess, layer_stats, layer_subplot_aess, layer_subplot_datas,
+     scales, guides) = render_prepare(plot)
+
     root_context = render_prepared(plot, coord, plot_aes, layer_aess,
                                    layer_stats, layer_subplot_aess,
                                    layer_subplot_datas,
@@ -823,7 +833,8 @@ function render_prepared(plot::Plot,
                          layer_subplot_datas::Vector{Vector{Data}},
                          scales::Dict{Symbol, ScaleElement},
                          guides::Vector{GuideElement};
-                         table_only=false)
+                         table_only=false,
+                         dynamic=true)
     # III. Coordinates
     plot_context = Coord.apply_coordinate(coord, vcat(plot_aes,
                                           layer_aess), scales)
@@ -844,7 +855,7 @@ function render_prepared(plot::Plot,
     # V. Guides
     guide_contexts = Any[]
     for guide in guides
-        guide_context = render(guide, plot.theme, plot_aes)
+        guide_context = render(guide, plot.theme, plot_aes, dynamic)
         if guide_context != nothing
             append!(guide_contexts, guide_context)
         end

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -45,6 +45,10 @@ end
 
 const background = PanelBackground
 
+function render(guide::Gadfly.GuideElement, theme::Gadfly.Theme,
+                aes::Gadfly.Aesthetics, dynamic::Bool=true)
+    render(guide, theme, aes)
+end
 
 function render(guide::PanelBackground, theme::Gadfly.Theme,
                 aes::Gadfly.Aesthetics)
@@ -556,7 +560,7 @@ end
 
 
 function render(guide::XTicks, theme::Gadfly.Theme,
-                aes::Gadfly.Aesthetics)
+                aes::Gadfly.Aesthetics, dynamic::Bool=true)
     if guide.ticks == nothing
         return PositionedGuide[]
     end
@@ -603,21 +607,24 @@ function render(guide::XTicks, theme::Gadfly.Theme,
         strokedash(theme.grid_strokedash),
         svgclass("guide xgridlines yfixed"))
 
-    dynamic_grid_lines = compose!(
-        context(withjs=true),
-        line([[(t, 0h), (t, 1h)] for t in grids]),
-        visible(gridvisibility),
-        stroke(theme.grid_color),
-        linewidth(theme.grid_line_width),
-        strokedash(theme.grid_strokedash),
-        svgclass("guide xgridlines yfixed"),
-        svgattribute("gadfly:scale", scale),
-        jsplotdata("focused_xgrid_color",
-                   "\"#$(hex(theme.grid_color_focused))\""),
-        jsplotdata("unfocused_xgrid_color",
-                   "\"#$(hex(theme.grid_color))\""))
-
-    grid_lines = compose!(context(), static_grid_lines, dynamic_grid_lines)
+    if dynamic
+        dynamic_grid_lines = compose!(
+            context(withjs=true),
+            line([[(t, 0h), (t, 1h)] for t in grids]),
+            visible(gridvisibility),
+            stroke(theme.grid_color),
+            linewidth(theme.grid_line_width),
+            strokedash(theme.grid_strokedash),
+            svgclass("guide xgridlines yfixed"),
+            svgattribute("gadfly:scale", scale),
+            jsplotdata("focused_xgrid_color",
+                       "\"#$(hex(theme.grid_color_focused))\""),
+            jsplotdata("unfocused_xgrid_color",
+                       "\"#$(hex(theme.grid_color))\""))
+        grid_lines = compose!(context(), static_grid_lines, dynamic_grid_lines)
+    else
+        grid_lines = compose!(context(), static_grid_lines)
+    end
 
     if !guide.label
         return [PositionedGuide([grid_lines], 0, under_guide_position)]
@@ -734,7 +741,7 @@ end
 
 
 function render(guide::YTicks, theme::Gadfly.Theme,
-                aes::Gadfly.Aesthetics)
+                aes::Gadfly.Aesthetics, dynamic::Bool=true)
     if guide.ticks == nothing
         return PositionedGuide[]
     end
@@ -780,21 +787,24 @@ function render(guide::YTicks, theme::Gadfly.Theme,
         strokedash(theme.grid_strokedash),
         svgclass("guide ygridlines xfixed"))
 
-    dynamic_grid_lines = compose!(
-        context(withjs=true),
-        line([[(0w, t), (1w, t)] for t in grids]),
-        visible(gridvisibility),
-        stroke(theme.grid_color),
-        linewidth(theme.grid_line_width),
-        strokedash(theme.grid_strokedash),
-        svgclass("guide ygridlines xfixed"),
-        svgattribute("gadfly:scale", scale),
-        jsplotdata("focused_ygrid_color",
-                   "\"#$(hex(theme.grid_color_focused))\""),
-        jsplotdata("unfocused_ygrid_color",
+    if dynamic
+        dynamic_grid_lines = compose!(
+            context(withjs=true),
+            line([[(0w, t), (1w, t)] for t in grids]),
+            visible(gridvisibility),
+            stroke(theme.grid_color),
+            linewidth(theme.grid_line_width),
+            strokedash(theme.grid_strokedash),
+            svgclass("guide ygridlines xfixed"),
+            svgattribute("gadfly:scale", scale),
+            jsplotdata("focused_ygrid_color",
+                   "\"#$(    hex(theme.grid_color_focused))\""),
+            jsplotdata("unfocused_ygrid_color",
                    "\"#$(hex(theme.grid_color))\""))
-
-    grid_lines = compose!(context(), static_grid_lines, dynamic_grid_lines)
+        grid_lines = compose!(context(), static_grid_lines, dynamic_grid_lines)
+    else
+        grid_lines = compose!(context(), static_grid_lines)
+    end
 
     if !guide.label
         return [PositionedGuide([grid_lines], 0, under_guide_position)]


### PR DESCRIPTION
See #680. There is surely more work along those lines in the future, but this is a good start.

This also makes dynamic tick rendering optional, since this is the slowest part of guide-rendering and non-javascript renderers don't need it.
