### PR TITLE
Add line_style to Theme

### DIFF
--- a/src/geom/hline.jl
+++ b/src/geom/hline.jl
@@ -27,10 +27,13 @@ function render(geom::HLineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
     color = geom.color === nothing ? theme.default_color : geom.color
     size = geom.size === nothing ? theme.line_width : geom.size
 
+    line_style = theme.line_style == nothing ? [] : [strokedash(Gadfly.getStrokeVector(theme.line_style))]
+
     return compose!(
         context(),
         Compose.line([[(0w, y), (1w, y)] for y in aes.yintercept], geom.tag),
         stroke(color),
         linewidth(size),
-        svgclass("xfixed"))
+        svgclass("xfixed"),
+        line_style...)
 end

--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -81,6 +81,8 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
     XT, YT, CT = eltype(aes.x), eltype(aes.y), eltype(aes.color)
     XYT = @compat Tuple{XT, YT}
 
+    line_style = theme.line_style == nothing ? [] : [strokedash(Gadfly.getStrokeVector(theme.line_style))]
+
     if aes.group != nothing
         GT = eltype(aes.group)
 
@@ -138,7 +140,8 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
 
         ctx = compose!(ctx, Compose.line(points,geom.tag),
                       stroke(points_colors),
-                      svgclass(classes))
+                      svgclass(classes),
+                      line_style...)
 
     elseif length(aes.color) == 1 &&
             !(isa(aes.color, PooledDataArray) && length(levels(aes.color)) > 1)
@@ -150,7 +153,8 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
 
         ctx = compose!(ctx, Compose.line(points,geom.tag),
                        stroke(aes.color[1]),
-                       svgclass("geometry"))
+                       svgclass("geometry"),
+                       line_style...)
     else
         if !geom.preserve_order
             p = sortperm(aes.x)
@@ -197,7 +201,8 @@ function render(geom::LineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics)
 
         ctx = compose!(ctx, Compose.line(points,geom.tag),
                       stroke(points_colors),
-                      svgclass(classes))
+                      svgclass(classes),
+                      line_style...)
     end
 
     return compose!(ctx, fill(nothing), linewidth(theme.line_width))

--- a/src/geom/vline.jl
+++ b/src/geom/vline.jl
@@ -26,10 +26,13 @@ function render(geom::VLineGeometry, theme::Gadfly.Theme, aes::Gadfly.Aesthetics
     color = geom.color === nothing ? theme.default_color : geom.color
     size = geom.size === nothing ? theme.line_width : geom.size
 
+    line_style = theme.line_style == nothing ? [] : [strokedash(Gadfly.getStrokeVector(theme.line_style))]
+
     return compose!(
         context(),
         Compose.line([[(x, 0h), (x, 1h)] for x in aes.xintercept], geom.tag),
         stroke(color),
         linewidth(size),
-        svgclass("yfixed"))
+        svgclass("yfixed"),
+        line_style...)
 end

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -62,6 +62,20 @@ function default_middle_color(fill_color::TransparentColor)
         fill_color.alpha)
 end
 
+getStrokeVector(vec::AbstractVector) = vec
+
+function getStrokeVector(linestyle::Symbol)
+  dash = 12 * Compose.mm
+  dot = 3 * Compose.mm
+  gap = 2 * Compose.mm
+  linestyle == :solid && return nothing
+  linestyle == :dash && return [dash, gap]
+  linestyle == :dot && return [dot, gap]
+  linestyle == :dashdot && return [dash, gap, dot, gap]
+  linestyle == :dashdotdot && return [dash, gap, dot, gap, dot, gap]
+  error("unsupported linestyle: ", linestyle)
+end
+
 @varset Theme begin
     # If the color aesthetic is not mapped to anything, this is the color that
     # is used.
@@ -72,6 +86,10 @@ end
 
     # Width of lines in the line geometry.
     line_width,            Measure,         0.3mm
+
+    # type of dash style (a Compose.StrokeDash object which takes a vector of sold/missing/solid/missing/... 
+    # lengths which are applied cyclically)
+    line_style,            Maybe(Vector),   nothing
 
     # Background color of the plot.
     panel_fill,            ColorOrNothing,  nothing


### PR DESCRIPTION
Addresses: #392 and probably others.

Theme will now accept a `line_style` argument.  If passed a vector, it converts into a sequence similar to [this example](https://github.com/dcjones/Compose.jl/blob/master/examples/dashedlines.jl).  If passed a symbol, it will return a pre-defined vector for that symbol (or throw an error if there isn't a pre-defined value for that symbol).

For line/hline/vline, if there is a value in the Theme for line_style, it will add a `strokedash` argument to the compose call.

Example:
```
using Plots
plot(cumsum(randn(10,5),1)+5, w=5, style=:auto, t=:line)
plot!(rand(1,10)*10, w=5, style=:auto, t=[:vline,:hline])
```

![tmp](https://cloud.githubusercontent.com/assets/933338/9964488/8293d224-5dfe-11e5-89e2-75e31b9dfd4a.png)

