### PR TITLE
bar_opacity Theme property and support in Geom.bar to render blended bars

### DIFF
--- a/src/geom/bar.jl
+++ b/src/geom/bar.jl
@@ -81,7 +81,7 @@ function render_colorless_bar(geom::BarGeometry,
             svgclass("geometry"))
     end
 
-    compose!(ctx, fill(theme.default_color))
+    compose!(ctx, fill(theme.default_color), fillopacity(theme.bar_opacity))
     if isa(theme.bar_highlight, Function)
         compose!(ctx, stroke(theme.bar_highlight(theme.default_color)))
     elseif isa(theme.bar_highlight, Color)
@@ -153,7 +153,7 @@ function render_colorful_stacked_bar(geom::BarGeometry,
     end
 
     cs = [aes.color[i] for i in idxs]
-    compose!(ctx, fill(cs), svgclass("geometry"))
+    compose!(ctx, fill(cs), fillopacity(theme.bar_opacity), svgclass("geometry"))
     if isa(theme.bar_highlight, Function)
         compose!(ctx, stroke([theme.bar_highlight(c) for c in cs]))
     elseif isa(theme.bar_highlight, Color)
@@ -247,7 +247,7 @@ function render_colorful_dodged_bar(geom::BarGeometry,
     end
 
     cs = [aes.color[i] for i in idxs]
-    compose!(ctx, fill(cs), svgclass("geometry"))
+    compose!(ctx, fill(cs), fillopacity(theme.bar_opacity), svgclass("geometry"))
     if isa(theme.bar_highlight, Function)
         compose!(ctx, stroke([theme.bar_highlight(c) for c in cs]))
     elseif isa(theme.bar_highlight, Color)

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -129,6 +129,9 @@ end
     # Spacing between bars for Geom.bar.
     bar_spacing,           Measure,         -0.05mm
 
+    # Opacity of bars for Geom.bar.
+    bar_opacity,           Float64,        1.0
+
     # Spacing between boxplots in Geom.boxplot.
     boxplot_spacing,       Measure,         1mm
 


### PR DESCRIPTION
Simple change that allows plotting of overlapping histograms.

Example use:
```julia
using Gadfly
using Distributions

aa = rand(Normal(), 3000)
ab = rand(Normal(1.5, 1), 3000)

plot(layer(x=aa, Geom.histogram,Theme(default_color=colorant"#ffccee",bar_opacity=0.7)),
     layer(x=ab, Geom.histogram,Theme(bar_opacity=0.7)))
```
which produces:
![bar_opacity](https://cloud.githubusercontent.com/assets/6378937/9977758/22a627e2-5ed8-11e5-93f9-af47751e7439.png)
Minor issue: Drawing to SVG target works correctly, but PNG target isn't quite right. (I made no changes to any of the draw targets; does this behavior show up with ribbons as well?) For the above image, I saved as svg and afterwards converted to png.