### PR TITLE
Reset pan and zoom on double click

### DIFF
--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -161,6 +161,10 @@ Gadfly.plot_mouseover = function(event) {
         .animate({opacity: 1.0}, 250);
 };
 
+// Reset pan and zoom on double click
+Gadfly.plot_dblclick = function(event) {
+  set_plot_pan_zoom(this.plotroot(), 0.0, 0.0, 1.0);
+};
 
 // Unemphasize grid lines on mouse out.
 Gadfly.plot_mouseout = function(event) {

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -1160,6 +1160,7 @@ function layout_guides(plot_context::Context,
                     """
                     mouseenter(Gadfly.plot_mouseover)
                     .mouseleave(Gadfly.plot_mouseout)
+                    .dblclick(Gadfly.plot_dblclick)
                     .mousewheel(Gadfly.guide_background_scroll)
                     .drag(Gadfly.guide_background_drag_onmove,
                           Gadfly.guide_background_drag_onstart,


### PR DESCRIPTION
This adds the functionality to reset the zoom and pan of a plot by double clicking, like it works in Matlab.