### PR TITLE
Union() -> Union{}

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -36,7 +36,7 @@ function __init__()
 end
 
 
-typealias ColorOrNothing Union(Colorant, (@compat Void))
+typealias ColorOrNothing @compat(Union{Colorant, (@compat Void)})
 
 element_aesthetics(::Any) = []
 input_aesthetics(::Any) = []
@@ -65,7 +65,7 @@ include("aesthetics.jl")
 
 # The layer and plot functions can also take functions that are evaluated with
 # no arguments and are expected to produce an element.
-typealias ElementOrFunction{T <: Element} Union(Element, Base.Callable, Theme)
+typealias ElementOrFunction{T <: Element} @compat(Union{Element, Base.Callable, Theme})
 
 const gadflyjs = joinpath(dirname(Base.source_path()), "gadfly.js")
 
@@ -86,11 +86,11 @@ end
 # A plot has zero or more layers. Layers have a particular geometry and their
 # own data, which is inherited from the plot if not given.
 type Layer <: Element
-    data_source::Union(AbstractDataFrame, (@compat Void))
+    data_source::@compat(Union{AbstractDataFrame, (@compat Void)})
     mapping::Dict
     statistics::Vector{StatisticElement}
     geom::GeometryElement
-    theme::Union((@compat Void), Theme)
+    theme::@compat(Union{(@compat Void), Theme})
     order::Int
 
     function Layer()
@@ -112,7 +112,7 @@ end
 
 
 
-function layer(data_source::Union(AbstractDataFrame, (@compat Void)),
+function layer(data_source::@compat(Union{AbstractDataFrame, (@compat Void)}),
                elements::ElementOrFunction...; mapping...)
     mapping = Dict{Symbol, Any}(mapping)
     lyr = Layer()
@@ -172,11 +172,11 @@ end
 # A full plot specification.
 type Plot
     layers::Vector{Layer}
-    data_source::Union((@compat Void), AbstractDataFrame)
+    data_source::@compat(Union{(@compat Void), AbstractDataFrame})
     data::Data
     scales::Vector{ScaleElement}
     statistics::Vector{StatisticElement}
-    coord::Union((@compat Void), CoordinateElement)
+    coord::@compat(Union{(@compat Void), CoordinateElement})
     guides::Vector{GuideElement}
     theme::Theme
     mapping::Dict
@@ -317,8 +317,8 @@ eval_plot_mapping(data::AbstractDataFrame, arg::Function) = arg
 eval_plot_mapping(data::AbstractDataFrame, arg::Distribution) = arg
 
 # Acceptable types of values that can be bound to aesthetics.
-typealias AestheticValue Union((@compat Void), Symbol, AbstractString, Integer, Expr,
-                               AbstractArray, Function, Distribution)
+typealias AestheticValue @compat(Union{(@compat Void), Symbol, AbstractString, Integer, Expr,
+                               AbstractArray, Function, Distribution})
 
 
 # Create a new plot.
@@ -342,7 +342,7 @@ typealias AestheticValue Union((@compat Void), Symbol, AbstractString, Integer, 
 # because a call to layer() expands to a vector of layers (one for each Geom
 # supplied), we need to allow Vector{Layer} to count as an Element for the
 # purposes of plot().
-typealias ElementOrFunctionOrLayers Union(ElementOrFunction, Vector{Layer})
+typealias ElementOrFunctionOrLayers @compat(Union{ElementOrFunction, Vector{Layer}})
 
 function plot(data_source::AbstractDataFrame, elements::ElementOrFunctionOrLayers...; mapping...)
     p = Plot()
@@ -1149,7 +1149,7 @@ const default_aes_scales = @compat Dict{Symbol, Dict}(
 
 # Determine whether the input is categorical or numerical
 
-typealias CategoricalType Union(AbstractString, Bool, Symbol)
+typealias CategoricalType @compat(Union{AbstractString, Bool, Symbol})
 
 
 function classify_data{N, T <: CategoricalType}(data::AbstractArray{T, N})

--- a/src/aesthetics.jl
+++ b/src/aesthetics.jl
@@ -1,22 +1,22 @@
 
 
 typealias NumericalOrCategoricalAesthetic
-    Union((@compat Void), Vector, DataArray, PooledDataArray)
+    @compat(Union{(@compat Void), Vector, DataArray, PooledDataArray})
 
 typealias CategoricalAesthetic
-    Union((@compat Void), PooledDataArray)
+    @compat(Union{(@compat Void), PooledDataArray})
 
 typealias NumericalAesthetic
-    Union((@compat Void), Matrix, Vector, DataArray)
+    @compat(Union{(@compat Void), Matrix, Vector, DataArray})
 
 
 @varset Aesthetics begin
-    x,            Union(NumericalOrCategoricalAesthetic, Distribution)
-    y,            Union(NumericalOrCategoricalAesthetic, Distribution)
-    z,            Union((@compat Void), Function, Matrix)
+    x,            @compat(Union{NumericalOrCategoricalAesthetic, Distribution})
+    y,            @compat(Union{NumericalOrCategoricalAesthetic, Distribution})
+    z,            @compat(Union{(@compat Void), Function, Matrix})
     size,         Maybe(Vector{Measure})
-    color,        Maybe(Union(AbstractVector{RGBA{Float32}},
-                              AbstractVector{RGB{Float32}}))
+    color,        Maybe(@compat(Union{AbstractVector{RGBA{Float32}},
+                              AbstractVector{RGB{Float32}}}))
     label,        CategoricalAesthetic
     group,        CategoricalAesthetic
 
@@ -352,7 +352,7 @@ end
 #   A Array{Aesthetics} of size max(1, length(xgroup)) by
 #   max(1, length(ygroup))
 #
-function by_xy_group{T <: Union(Data, Aesthetics)}(aes::T, xgroup, ygroup,
+function by_xy_group{T <: @compat(Union{Data, Aesthetics})}(aes::T, xgroup, ygroup,
                                                    num_xgroups, num_ygroups)
     @assert xgroup === nothing || ygroup === nothing ||
             length(xgroup) == length(ygroup)

--- a/src/coord.jl
+++ b/src/coord.jl
@@ -31,7 +31,7 @@ immutable Cartesian <: Gadfly.CoordinateElement
     xflip::Bool
     yflip::Bool
     fixed::Bool
-    aspect_ratio::Union((@compat Void), Float64)
+    aspect_ratio::@compat(Union{(@compat Void), Float64})
     raster::Bool
 
     function Cartesian(
@@ -109,7 +109,7 @@ end
 #   A common type.
 function aesthetics_type(aess::Vector{Gadfly.Aesthetics},
                               vars::Vector{Symbol})
-    T = None
+    T = @compat(Union{})
     for var in vars
         for aes in aess
             vals = getfield(aes, var)
@@ -263,4 +263,3 @@ end
 const subplot_grid = SubplotGrid
 
 end # module Coord
-

--- a/src/geom/hline.jl
+++ b/src/geom/hline.jl
@@ -1,11 +1,11 @@
 
 immutable HLineGeometry <: Gadfly.GeometryElement
-    color::Union(Color, (@compat Void))
-    size::Union(Measure, (@compat Void))
+    color::@compat(Union{Color, (@compat Void)})
+    size::@compat(Union{Measure, (@compat Void)})
     tag::Symbol
 
     function HLineGeometry(; color=nothing,
-                           size::Union(Measure, (@compat Void))=nothing,
+                           size::@compat(Union{Measure, (@compat Void)})=nothing,
                            tag::Symbol=empty_tag)
         new(color === nothing ? nothing : Colors.color(color),
             size, tag)

--- a/src/geom/vline.jl
+++ b/src/geom/vline.jl
@@ -1,11 +1,11 @@
 
 immutable VLineGeometry <: Gadfly.GeometryElement
-    color::Union(Color, (@compat Void))
-    size::Union(Measure, (@compat Void))
+    color::@compat(Union{Color, (@compat Void)})
+    size::@compat(Union{Measure, (@compat Void)})
     tag::Symbol
 
     function VLineGeometry(; color=nothing,
-                           size::Union(Measure, (@compat Void))=nothing,
+                           size::@compat(Union{Measure, (@compat Void)})=nothing,
                            tag::Symbol=empty_tag)
         new(color === nothing ? nothing : Colors.color(color), size, tag)
     end

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -41,8 +41,8 @@ end
 # Subplot geometries require some more arguments to render. A simpler render
 # function is defined and passed through to here for non-subplot geometries.
 function render(geom::Gadfly.GeometryElement, theme::Gadfly.Theme, aes::Gadfly.Aesthetics,
-                subplot_layer_aess::Union((@compat Void), Vector{Gadfly.Aesthetics}),
-                subplot_layer_datas::Union((@compat Void), Vector{Gadfly.Data}),
+                subplot_layer_aess::@compat(Union{(@compat Void), Vector{Gadfly.Aesthetics}}),
+                subplot_layer_datas::@compat(Union{(@compat Void), Vector{Gadfly.Data}}),
                 scales::Dict{Symbol, ScaleElement})
     render(geom, theme, aes)
 end

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -173,7 +173,7 @@ end
 
 
 immutable ColorKey <: Gadfly.GuideElement
-    title::Union(AbstractString, (@compat Void))
+    title::@compat(Union{AbstractString, (@compat Void)})
 
     function ColorKey(title=nothing)
         new(title)
@@ -481,7 +481,7 @@ end
 
 
 immutable ManualColorKey{C<:Color} <: Gadfly.GuideElement
-    title::Union(AbstractString, (@compat Void))
+    title::@compat(Union{AbstractString, (@compat Void)})
     labels::Vector{AbstractString}
     colors::Vector{C}
 end
@@ -534,11 +534,11 @@ end
 
 immutable XTicks <: Gadfly.GuideElement
     label::Bool
-    ticks::Union((@compat Void), Symbol, AbstractArray)
+    ticks::@compat(Union{(@compat Void), Symbol, AbstractArray})
     orientation::Symbol
 
     function XTicks(; label::Bool=true,
-                      ticks::Union((@compat Void), Symbol, AbstractArray)=:auto,
+                      ticks::@compat(Union{(@compat Void), Symbol, AbstractArray})=:auto,
                       orientation::Symbol=:auto)
         if isa(ticks, Symbol) && ticks != :auto
             error("$(ticks) is not a valid value for the `ticks` parameter")
@@ -714,11 +714,11 @@ end
 
 immutable YTicks <: Gadfly.GuideElement
     label::Bool
-    ticks::Union((@compat Void), Symbol, AbstractArray)
+    ticks::@compat(Union{(@compat Void), Symbol, AbstractArray})
     orientation::Symbol
 
     function YTicks(; label::Bool=true,
-                      ticks::Union((@compat Void), Symbol, AbstractArray)=:auto,
+                      ticks::@compat(Union{(@compat Void), Symbol, AbstractArray})=:auto,
                       orientation::Symbol=:horizontal)
         if isa(ticks, Symbol) && ticks != :auto
             error("$(ticks) is not a valid value for the `ticks` parameter")
@@ -896,7 +896,7 @@ end
 
 # X-axis label Guide
 immutable XLabel <: Gadfly.GuideElement
-    label::Union((@compat Void), AbstractString)
+    label::@compat(Union{(@compat Void), AbstractString})
     orientation::Symbol
 
     function XLabel(label; orientation::Symbol=:auto)
@@ -961,7 +961,7 @@ end
 
 # Y-axis label Guide
 immutable YLabel <: Gadfly.GuideElement
-    label::Union((@compat Void), AbstractString)
+    label::@compat(Union{(@compat Void), AbstractString})
     orientation::Symbol
 
     function YLabel(label; orientation::Symbol=:auto)
@@ -1019,7 +1019,7 @@ end
 
 # Title Guide
 immutable Title <: Gadfly.GuideElement
-    label::Union((@compat Void), AbstractString)
+    label::@compat(Union{(@compat Void), AbstractString})
 end
 
 const title = Title

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -286,7 +286,7 @@ function has{T,N}(xs::AbstractArray{T,N}, y::T)
     return false
 end
 
-Maybe(T) = Union(T, (@compat Void))
+Maybe(T) = @compat(Union{T, (@compat Void)})
 
 
 function lerp(x::Float64, a::Float64, b::Float64)
@@ -378,7 +378,7 @@ end
 if VERSION < v"0.4-dev"
     using Dates
 
-    function Showoff.showoff{T <: Union(Date, DateTime)}(ds::AbstractArray{T}, style=:none)
+    function Showoff.showoff{T <: @compat(Union{Date, DateTime})}(ds::AbstractArray{T}, style=:none)
         years = Set()
         months = Set()
         days = Set()

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -127,7 +127,7 @@ immutable ContinuousScale <: Gadfly.ScaleElement
     maxvalue
     minticks
     maxticks
-    labels::Union((@compat Void), Function)
+    labels::@compat(Union{(@compat Void), Function})
     format
     scalable
 
@@ -373,14 +373,14 @@ immutable DiscreteScale <: Gadfly.ScaleElement
     # an array of string labels, a vector of string labels of the same length
     # as the number of unique values in the discrete data, or nothing to use
     # the default labels.
-    labels::Union((@compat Void), Function)
+    labels::@compat(Union{(@compat Void), Function})
 
     # If non-nothing, give values for the scale. Order will be respected and
     # anything in the data that's not represented in values will be set to NA.
-    levels::Union((@compat Void), AbstractVector)
+    levels::@compat(Union{(@compat Void), AbstractVector})
 
     # If non-nothing, a permutation of the pool of values.
-    order::Union((@compat Void), AbstractVector)
+    order::@compat(Union{(@compat Void), AbstractVector})
 
     function DiscreteScale(vals::Vector{Symbol};
                            labels=nothing, levels=nothing, order=nothing)
@@ -478,10 +478,10 @@ immutable DiscreteColorScale <: Gadfly.ScaleElement
 
     # If non-nothing, give values for the scale. Order will be respected and
     # anything in the data that's not represented in values will be set to NA.
-    levels::Union((@compat Void), AbstractVector)
+    levels::@compat(Union{(@compat Void), AbstractVector})
 
     # If non-nothing, a permutation of the pool of values.
-    order::Union((@compat Void), AbstractVector)
+    order::@compat(Union{(@compat Void), AbstractVector})
 
     # If true, order levels as they appear in the data
     preserve_order::Bool

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -709,13 +709,13 @@ immutable TickStatistic <: Gadfly.StatisticElement
     niceness_weight::Float64
 
     # fixed ticks, or nothing
-    ticks::Union(Symbol, AbstractArray)
+    ticks::@compat(Union{Symbol, AbstractArray})
 end
 
 
 @deprecate xticks(ticks) xticks(ticks=ticks)
 
-function xticks(; ticks::Union(Symbol, AbstractArray)=:auto,
+function xticks(; ticks::@compat(Union{Symbol, AbstractArray})=:auto,
                   granularity_weight::Float64=1/4,
                   simplicity_weight::Float64=1/6,
                   coverage_weight::Float64=1/3,
@@ -728,7 +728,7 @@ end
 
 @deprecate yticks(ticks) yticks(ticks=ticks)
 
-function yticks(; ticks::Union(Symbol, AbstractArray)=:auto,
+function yticks(; ticks::@compat(Union{Symbol, AbstractArray})=:auto,
                   granularity_weight::Float64=1/4,
                   simplicity_weight::Float64=1/6,
                   coverage_weight::Float64=1/3,
@@ -1591,7 +1591,7 @@ function apply_statistic(stat::QQStatistic,
     # NumericalOrCategoricalAesthetic.  The .x and .y fields are the _only_
     # place where this type is used, but I'm not sure if there's a reason that
     # changing this typealias would be a bad idea...for now I've just used a
-    # direct `Union(NumericalOrCategoricalAesthetic, Distribution)`.
+    # direct `@compat(Union{NumericalOrCategoricalAesthetic, Distribution})`.
     #
     # TODO:
     #

--- a/src/theme.jl
+++ b/src/theme.jl
@@ -173,7 +173,7 @@ end
     key_position,          Symbol,          :right
 
     # True if bars in bar plots should be stroked. Stroke color is
-    bar_highlight,         Union((@compat Void), Function, Color),   nothing
+    bar_highlight,         @compat(Union{(@compat Void), Function, Color}),   nothing
 
     # TODO: This stuff is too incomprehensible to be in theme, I think. Put it
     # somewhere else.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,7 +105,7 @@ tests = [
 ]
 
 
-backends = @compat Dict{String, Function}(
+backends = @compat Dict{AbstractString, Function}(
     "svg" => (name, width, height) -> SVG("output/$(name).svg", width, height),
     "svgjs" => (name, width, height) -> SVGJS("output/$(name).js.svg", width, height, jsmode=:linkabs),
     "png" => (name, width, height) -> PNG("output/$(name).png", width, height),


### PR DESCRIPTION
Companion of https://github.com/dcjones/Compose.jl/pull/158

There are still a few concatenation and
```
WARNING: Base.Uint8 is deprecated, use UInt8 instead.
```
warnings (presumably due to dependencies), but this gets rid of the vast majority of them.