### PR TITLE
Add box zoom functionality

### DIFF
--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -714,7 +714,7 @@ var zoom_action = {
 
 Gadfly.guide_background_drag_onstart = function(x, y, event) {
     var root = this.plotroot();
-    var scalable = root.hasClass("xscalable") || root.hasClass("xscalable");
+    var scalable = root.hasClass("xscalable") || root.hasClass("yscalable");
     var zoomable = !event.altKey && !event.ctrlKey && event.shiftKey && scalable;
     var panable = !event.altKey && !event.ctrlKey && !event.shiftKey && scalable;
     var drag_action = zoomable ? zoom_action :

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -150,6 +150,7 @@ var modifiers;
 
 var statechanged = function(event) {
     var root = Snap(this).plotroot();
+    root.data("can_zoom", !modifiers.altKey && !modifiers.ctrlKey && modifiers.shiftKey);
 };
 
 var keyfunction = function(plot, event) {
@@ -623,8 +624,8 @@ Gadfly.guide_background_drag_onend = function(event) {
 
 
 Gadfly.guide_background_scroll = function(event) {
-    if (event.shiftKey) {
-        var root = this.plotroot();
+    var root = this.plotroot();
+    if (root.data("can_zoom")) {
         init_pan_zoom(root);
         var new_scale = root.data("scale") * Math.pow(2, 0.002 * event.wheelDelta);
         new_scale = Math.max(

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -744,8 +744,8 @@ Gadfly.guide_background_drag_onend = function(event) {
 
 
 Gadfly.guide_background_scroll = function(event) {
-    var root = this.plotroot();
-    if (root.data("can_zoom")) {
+    if (event.shiftKey) {
+        var root = this.plotroot();
         init_pan_zoom(root);
         var new_scale = root.data("scale") * Math.pow(2, 0.002 * event.wheelDelta);
         new_scale = Math.max(

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -709,6 +709,14 @@ Gadfly.guide_background_drag_onstart = function(x, y, event) {
                                  undefined;
     root.data("drag_action", drag_action);
     if (drag_action) {
+        var cancel_drag_action = function(event) {
+            if (event.which == 27) { // esc key
+                drag_action.cancel(root);
+                root.data("drag_action", undefined);
+            }
+        };
+        window.addEventListener("keyup", cancel_drag_action);
+        root.data("cancel_drag_action", cancel_drag_action);
         drag_action.start(root, x, y, event);
     }
 };
@@ -725,6 +733,8 @@ Gadfly.guide_background_drag_onmove = function(dx, dy, x, y, event) {
 
 Gadfly.guide_background_drag_onend = function(event) {
     var root = this.plotroot();
+    window.removeEventListener("keyup", root.data("cancel_drag_action"));
+    root.data("cancel_drag_action", undefined);
     var drag_action = root.data("drag_action");
     if (drag_action) {
         drag_action.end(root, event);

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -151,6 +151,7 @@ var modifiers;
 var statechanged = function(event) {
     var root = Snap(this).plotroot();
     root.data("can_zoom", !modifiers.altKey && !modifiers.ctrlKey && modifiers.shiftKey);
+    root.data("can_pan", !modifiers.altKey && !modifiers.ctrlKey && !modifiers.shiftKey);
 };
 
 var keyfunction = function(plot, event) {
@@ -587,34 +588,38 @@ var init_pan_zoom = function(root) {
 // Panning
 Gadfly.guide_background_drag_onmove = function(dx, dy, x, y, event) {
     var root = this.plotroot();
-    var px_per_mm = root.data("px_per_mm");
-    dx /= px_per_mm;
-    dy /= px_per_mm;
+    if (root.data("can_pan")) {
+        var px_per_mm = root.data("px_per_mm");
+        dx /= px_per_mm;
+        dy /= px_per_mm;
 
-    var tx0 = root.data("tx"),
-        ty0 = root.data("ty");
+        var tx0 = root.data("tx"),
+            ty0 = root.data("ty");
 
-    var dx0 = root.data("dx"),
-        dy0 = root.data("dy");
+        var dx0 = root.data("dx"),
+            dy0 = root.data("dy");
 
-    root.data("dx", dx);
-    root.data("dy", dy);
+        root.data("dx", dx);
+        root.data("dy", dy);
 
-    dx = dx - dx0;
-    dy = dy - dy0;
+        dx = dx - dx0;
+        dy = dy - dy0;
 
-    var tx = tx0 + dx,
-        ty = ty0 + dy;
+        var tx = tx0 + dx,
+            ty = ty0 + dy;
 
-    set_plot_pan_zoom(root, tx, ty, root.data("scale"));
+        set_plot_pan_zoom(root, tx, ty, root.data("scale"));
+    }
 };
 
 
 Gadfly.guide_background_drag_onstart = function(x, y, event) {
     var root = this.plotroot();
-    root.data("dx", 0);
-    root.data("dy", 0);
-    init_pan_zoom(root);
+    if (root.data("can_pan")) {
+        root.data("dx", 0);
+        root.data("dy", 0);
+        init_pan_zoom(root);
+    }
 };
 
 

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -137,7 +137,10 @@ Snap.plugin(function (Snap, Element, Paper, global) {
             .mousewheel(Gadfly.guide_background_scroll)
             .drag(Gadfly.guide_background_drag_onmove,
                   Gadfly.guide_background_drag_onstart,
-                  Gadfly.guide_background_drag_onend);
+                  Gadfly.guide_background_drag_onend)
+            .drag(Gadfly.guide_background_boxzoom_onmove,
+                  Gadfly.guide_background_boxzoom_onstart,
+                  Gadfly.guide_background_boxzoom_onend);
         var plot = this;
         this.node.addEventListener("statechanged", statechanged);
         window.addEventListener("keydown", function(e) { keyfunction(plot, e); });
@@ -625,6 +628,86 @@ Gadfly.guide_background_drag_onstart = function(x, y, event) {
 
 Gadfly.guide_background_drag_onend = function(event) {
     var root = this.plotroot();
+};
+
+
+var box;
+
+
+Gadfly.guide_background_boxzoom_onstart = function(x, y, event) {
+    var root = this.plotroot();
+    if (root.data("can_zoom")) {
+        var bounds = root.plotbounds();
+        var width = bounds.x1 - bounds.x0,
+            height = bounds.y1 - bounds.y0;
+        var ratio = width / height;
+        var px_per_mm = root.data("px_per_mm");
+        x /= px_per_mm;
+        y /= px_per_mm;
+        box = root.rect(x, y, 0, 0).attr({
+            "fill": "#000",
+            "opacity": 0.25
+        });
+        box.data("ratio", ratio);
+    }
+};
+
+
+Gadfly.guide_background_boxzoom_onmove = function(dx, dy, x, y, event) {
+    var root = this.plotroot();
+    if (root.data("can_zoom")) {
+        var px_per_mm = root.data("px_per_mm");
+        var bounds = root.plotbounds();
+        x /= px_per_mm;
+        x = Math.max(bounds.x0, x);
+        x = Math.min(bounds.x1, x);
+        y /= px_per_mm;
+        y = Math.max(bounds.y0, y);
+        y = Math.min(bounds.y1, y);
+        dx = x - box.attr("x");
+        dy = y - box.attr("y");
+        var ratio = box.data("ratio");
+        var width = Math.min(Math.abs(dx), ratio * Math.abs(dy));
+        var height = Math.min(Math.abs(dy), Math.abs(dx) / ratio);
+        dx = width * dx / Math.abs(dx);
+        dy = height * dy / Math.abs(dy);
+        var xoffset = 0,
+            yoffset = 0;
+        if (dx < 0) {
+            xoffset = dx;
+            dx = -1 * dx;
+        }
+        if (dy < 0) {
+            yoffset = dy;
+            dy = -1 * dy;
+        }
+        if (isNaN(dy)) {
+            dy = 0.0;
+        }
+        if (isNaN(dx)) {
+            dx = 0.0;
+        }
+        box.transform("T" + xoffset + "," + yoffset);
+        box.attr("width", dx);
+        box.attr("height", dy);
+    }
+};
+
+Gadfly.guide_background_boxzoom_onend = function(event) {
+    var root = this.plotroot();
+    if (root.data("can_zoom")) {
+        var px_per_mm = root.data("px_per_mm");
+        var zoom_bounds = box.getBBox();
+        if (zoom_bounds.width * zoom_bounds.height <= 0) {
+            return;
+        }
+        var plot_bounds = root.plotbounds();
+        var zoom_factor = (plot_bounds.y1 - plot_bounds.y0) / zoom_bounds.height;
+        var tx = (root.data("tx") - zoom_bounds.x) * zoom_factor + plot_bounds.x0,
+            ty = (root.data("ty") - zoom_bounds.y) * zoom_factor + plot_bounds.y0;
+        set_plot_pan_zoom(root, tx, ty, root.data("scale") * zoom_factor);
+        box.remove();
+    }
 };
 
 

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -148,6 +148,16 @@ Snap.plugin(function (Snap, Element, Paper, global) {
 Gadfly.plot_mouseover = function(event) {
     var root = this.plotroot();
 
+    var keyboard_zoom = function(event) {
+        if (event.which == 187) { // plus
+            set_zoom(root, root.data("scale") * 1.5, true);
+        } else if (event.which == 189) { // minus
+            set_zoom(root, root.data("scale") / 1.5, true);
+        }
+    };
+    root.data("keyboard_zoom", keyboard_zoom);
+    window.addEventListener("keyup", keyboard_zoom);
+
     var xgridlines = root.select(".xgridlines"),
         ygridlines = root.select(".ygridlines");
 
@@ -180,6 +190,10 @@ Gadfly.plot_dblclick = function(event) {
 // Unemphasize grid lines on mouse out.
 Gadfly.plot_mouseout = function(event) {
     var root = this.plotroot();
+
+    window.removeEventListener("keyup", root.data("keyboard_zoom"));
+    root.data("keyboard_zoom", undefined);
+
     var xgridlines = root.select(".xgridlines"),
         ygridlines = root.select(".ygridlines");
 

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -138,10 +138,28 @@ Snap.plugin(function (Snap, Element, Paper, global) {
             .drag(Gadfly.guide_background_drag_onmove,
                   Gadfly.guide_background_drag_onstart,
                   Gadfly.guide_background_drag_onend);
+        var plot = this;
+        this.node.addEventListener("statechanged", statechanged);
+        window.addEventListener("keydown", function(e) { keyfunction(plot, e); });
+        window.addEventListener("keyup", function(e) { keyfunction(plot, e); });
         return this;
     };
 });
 
+var modifiers;
+
+var statechanged = function(event) {
+    var root = Snap(this).plotroot();
+};
+
+var keyfunction = function(plot, event) {
+    modifiers = {
+        altKey: event.altKey,
+        ctrlKey: event.ctrlKey,
+        shiftKey: event.shiftKey
+    };
+    plot.node.dispatchEvent(new Event("statechanged"));
+};
 
 // When the plot is moused over, emphasize the grid lines.
 Gadfly.plot_mouseover = function(event) {

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -138,6 +138,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
             .drag(Gadfly.guide_background_drag_onmove,
                   Gadfly.guide_background_drag_onstart,
                   Gadfly.guide_background_drag_onend);
+        init_pan_zoom(this.plotroot());
         return this;
     };
 });
@@ -146,7 +147,6 @@ Snap.plugin(function (Snap, Element, Paper, global) {
 // When the plot is moused over, emphasize the grid lines.
 Gadfly.plot_mouseover = function(event) {
     var root = this.plotroot();
-    init_pan_zoom(root);
 
     var xgridlines = root.select(".xgridlines"),
         ygridlines = root.select(".ygridlines");
@@ -572,7 +572,6 @@ var pan_action = {
         root.data("dy", 0);
         root.data("tx0", root.data("tx"));
         root.data("ty0", root.data("ty"));
-        init_pan_zoom(root);
     },
     update: function(root, dx, dy, x, y, event) {
         var px_per_mm = root.data("px_per_mm");
@@ -746,7 +745,6 @@ Gadfly.guide_background_drag_onend = function(event) {
 Gadfly.guide_background_scroll = function(event) {
     if (event.shiftKey) {
         var root = this.plotroot();
-        init_pan_zoom(root);
         var new_scale = root.data("scale") * Math.pow(2, 0.002 * event.wheelDelta);
         new_scale = Math.max(
             root.data("min_scale"),
@@ -771,7 +769,6 @@ Gadfly.zoomslider_button_mouseout = function(event) {
 
 Gadfly.zoomslider_zoomout_click = function(event) {
     var root = this.plotroot();
-    init_pan_zoom(root);
     var min_scale = root.data("min_scale"),
         scale = root.data("scale");
     Snap.animate(
@@ -786,7 +783,6 @@ Gadfly.zoomslider_zoomout_click = function(event) {
 
 Gadfly.zoomslider_zoomin_click = function(event) {
     var root = this.plotroot();
-    init_pan_zoom(root);
     var max_scale = root.data("max_scale"),
         scale = root.data("scale");
 
@@ -878,7 +874,6 @@ Gadfly.zoomslider_thumb_dragmove = function(dx, dy, x, y) {
 
 Gadfly.zoomslider_thumb_dragstart = function(event) {
     var root = this.plotroot();
-    init_pan_zoom(root);
 
     // keep track of what the scale was when we started dragging
     root.data("old_scale", root.data("scale"));

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -691,7 +691,6 @@ var zoom_action = {
     end: function(root, event) {
         var xscalable = root.hasClass("xscalable"),
             yscalable = root.hasClass("yscalable");
-        var px_per_mm = root.data("px_per_mm");
         var zoom_bounds = zoom_box.getBBox();
         if (zoom_bounds.width * zoom_bounds.height <= 0) {
             return;

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -746,10 +746,7 @@ Gadfly.guide_background_scroll = function(event) {
     if (event.shiftKey) {
         var root = this.plotroot();
         var new_scale = root.data("scale") * Math.pow(2, 0.002 * event.wheelDelta);
-        new_scale = Math.max(
-            root.data("min_scale"),
-            Math.min(root.data("max_scale"), new_scale))
-        update_plot_scale(root, new_scale);
+        set_zoom(root, new_scale);
         event.preventDefault();
     }
 };
@@ -769,30 +766,13 @@ Gadfly.zoomslider_button_mouseout = function(event) {
 
 Gadfly.zoomslider_zoomout_click = function(event) {
     var root = this.plotroot();
-    var min_scale = root.data("min_scale"),
-        scale = root.data("scale");
-    Snap.animate(
-        scale,
-        Math.max(min_scale, scale / 1.5),
-        function (new_scale) {
-            update_plot_scale(root, new_scale);
-        },
-        200);
+    set_zoom(root, root.data("scale") / 1.5, true);
 };
 
 
 Gadfly.zoomslider_zoomin_click = function(event) {
     var root = this.plotroot();
-    var max_scale = root.data("max_scale"),
-        scale = root.data("scale");
-
-    Snap.animate(
-        scale,
-        Math.min(max_scale, scale * 1.5),
-        function (new_scale) {
-            update_plot_scale(root, new_scale);
-        },
-        200);
+    set_zoom(root, root.data("scale") * 1.5, true);
 };
 
 
@@ -818,6 +798,25 @@ var slider_position_from_scale = function(scale, min_scale, max_scale) {
     }
     else {
         return 0.5 * (Math.log(scale) - Math.log(min_scale)) / (0 - Math.log(min_scale));
+    }
+}
+
+
+var set_zoom = function(root, scale, animate) {
+    var min_scale = root.data("min_scale"),
+        max_scale = root.data("max_scale"),
+        old_scale = root.data("scale");
+    var new_scale = Math.max(min_scale, Math.min(scale, max_scale));
+    if (animate) {
+        Snap.animate(
+            old_scale,
+            new_scale,
+            function (new_scale) {
+                update_plot_scale(root, new_scale);
+            },
+            200);
+    } else {
+        update_plot_scale(root, new_scale);
     }
 }
 

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -161,6 +161,17 @@ var keyfunction = function(plot, event) {
         shiftKey: event.shiftKey
     };
     plot.node.dispatchEvent(new Event("statechanged"));
+    var root = plot.plotroot();
+    if (event.which == 27) { // esc key pressed
+        if (root.data("state") == "is_panning") {
+            root.data("state", undefined);
+            panning.cancel(root);
+        }
+        if (root.data("state") == "is_zooming") {
+            root.data("state", undefined);
+            zooming.cancel(root);
+        }
+    }
 };
 
 // When the plot is moused over, emphasize the grid lines.
@@ -589,6 +600,8 @@ var panning = {
     start: function(root, x, y, event) {
         root.data("dx", 0);
         root.data("dy", 0);
+        root.data("tx0", root.data("tx"));
+        root.data("ty0", root.data("ty"));
         init_pan_zoom(root);
     },
     update: function(root, dx, dy, x, y, event) {
@@ -615,6 +628,9 @@ var panning = {
     },
     end: function(root, event) {
 
+    },
+    cancel: function(root) {
+        set_plot_pan_zoom(root, root.data("tx0"), root.data("ty0"), root.data("scale"));
     }
 };
 
@@ -682,6 +698,9 @@ var zooming = {
         var tx = (root.data("tx") - zoom_bounds.x) * zoom_factor + plot_bounds.x0,
             ty = (root.data("ty") - zoom_bounds.y) * zoom_factor + plot_bounds.y0;
         set_plot_pan_zoom(root, tx, ty, root.data("scale") * zoom_factor);
+        box.remove();
+    },
+    cancel: function(root) {
         box.remove();
     }
 };

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -138,7 +138,9 @@ Snap.plugin(function (Snap, Element, Paper, global) {
             .drag(Gadfly.guide_background_drag_onmove,
                   Gadfly.guide_background_drag_onstart,
                   Gadfly.guide_background_drag_onend);
-        init_pan_zoom(this.plotroot());
+        this.mouseenter(function (event) {
+            init_pan_zoom(this.plotroot());
+        });
         return this;
     };
 });

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -854,7 +854,7 @@ var update_plot_scale = function(root, new_scale) {
 };
 
 
-Gadfly.zoomslider_thumb_dragmove = function(dx, dy, x, y) {
+Gadfly.zoomslider_thumb_dragmove = function(dx, dy, x, y, event) {
     var root = this.plotroot();
     var min_pos = this.data("min_pos"),
         max_pos = this.data("max_pos"),
@@ -882,18 +882,21 @@ Gadfly.zoomslider_thumb_dragmove = function(dx, dy, x, y) {
     new_scale = Math.min(max_scale, Math.max(min_scale, new_scale));
 
     update_plot_scale(root, new_scale);
+    event.stopPropagation();
 };
 
 
-Gadfly.zoomslider_thumb_dragstart = function(event) {
+Gadfly.zoomslider_thumb_dragstart = function(x, y, event) {
     var root = this.plotroot();
 
     // keep track of what the scale was when we started dragging
     root.data("old_scale", root.data("scale"));
+    event.stopPropagation();
 };
 
 
 Gadfly.zoomslider_thumb_dragend = function(event) {
+    event.stopPropagation();
 };
 
 

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -707,33 +707,36 @@ var zooming = {
 
 
 // Panning
-Gadfly.guide_background_drag_onmove = function(dx, dy, x, y, event) {
+Gadfly.guide_background_drag_onstart = function(x, y, event) {
     var root = this.plotroot();
     if (root.data("can_pan")) {
-        panning.update(root, dx, dy, x, y, event);
+        root.data("state", "is_panning");
+        panning.start(root, x, y, event);
     }
     if (root.data("can_zoom")) {
-        zooming.update(root, dx, dy, x, y, event);
+        root.data("state", "is_zooming");
+        zooming.start(root, x, y, event);
     }
 };
 
 
-Gadfly.guide_background_drag_onstart = function(x, y, event) {
+Gadfly.guide_background_drag_onmove = function(dx, dy, x, y, event) {
     var root = this.plotroot();
-    if (root.data("can_pan")) {
-        panning.start(root, x, y, event);
+    if (root.data("state") == "is_panning") {
+        panning.update(root, dx, dy, x, y, event);
     }
-    if (root.data("can_zoom")) {
-        zooming.start(root, x, y, event);
+    if (root.data("state") == "is_zooming") {
+        zooming.update(root, dx, dy, x, y, event);
     }
 };
 
 
 Gadfly.guide_background_drag_onend = function(event) {
     var root = this.plotroot();
-    if (root.data("can_zoom")) {
+    if (root.data("state") == "is_zooming") {
         zooming.end(root, event);
     }
+    root.data("state", undefined);
 };
 
 

--- a/src/gadfly.js
+++ b/src/gadfly.js
@@ -129,6 +129,17 @@ Snap.plugin(function (Snap, Element, Paper, global) {
             return this;
         }
     };
+
+    Element.prototype.init_gadfly = function() {
+        this.mouseenter(Gadfly.plot_mouseover)
+            .mouseleave(Gadfly.plot_mouseout)
+            .dblclick(Gadfly.plot_dblclick)
+            .mousewheel(Gadfly.guide_background_scroll)
+            .drag(Gadfly.guide_background_drag_onmove,
+                  Gadfly.guide_background_drag_onstart,
+                  Gadfly.guide_background_drag_onend);
+        return this;
+    };
 });
 
 

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -100,8 +100,8 @@ function render(guide::ZoomSlider, theme::Gadfly.Theme,
             .mouseenter(Gadfly.zoomslider_button_mouseover)
             .mouseleave(Gadfly.zoomslider_button_mouseout)
             """),
-        jsdata("mouseout_color", "\"$(foreground_color)\""),
-        jsdata("mouseover_color", "\"$(highlight_color)\""))
+        jsdata("mouseout_color", "\"#$(hex(foreground_color))\""),
+        jsdata("mouseover_color", "\"#$(hex(highlight_color))\""))
 
     slider_width = 2mm
     slider_xpos = 1w - edge_pad - button_size - slider_size + slide_pad
@@ -129,8 +129,8 @@ function render(guide::ZoomSlider, theme::Gadfly.Theme,
             .mousedown(Gadfly.zoomslider_thumb_mousedown)
             .mouseup(Gadfly.zoomslider_thumb_mouseup)
             """),
-         jsdata("mouseout_color", "\"$(foreground_color)\""),
-         jsdata("mouseover_color", "\"$(highlight_color)\""),
+         jsdata("mouseout_color", "\"#$(hex(foreground_color))\""),
+         jsdata("mouseover_color", "\"#$(hex(highlight_color))\""),
          jsdata("min_pos", "%x", Measure[slider_min_pos]),
          jsdata("max_pos", "%x", Measure[slider_max_pos])))
 
@@ -155,8 +155,8 @@ function render(guide::ZoomSlider, theme::Gadfly.Theme,
             .mouseenter(Gadfly.zoomslider_button_mouseover)
             .mouseleave(Gadfly.zoomslider_button_mouseout)
             """),
-        jsdata("mouseout_color", "\"$(foreground_color)\""),
-        jsdata("mouseover_color", "\"$(highlight_color)\""))
+        jsdata("mouseout_color", "\"#$(hex(foreground_color))\""),
+        jsdata("mouseover_color", "\"#$(hex(highlight_color))\""))
 
     root = compose!(
         context(withjs=true, units=UnitBox()),

--- a/src/guide.jl
+++ b/src/guide.jl
@@ -1156,16 +1156,7 @@ function layout_guides(plot_context::Context,
                       [c for (c, o) in guides[over_guide_position]]...],
                   (context(order=0),
                      plot_context),
-                  jscall(
-                    """
-                    mouseenter(Gadfly.plot_mouseover)
-                    .mouseleave(Gadfly.plot_mouseout)
-                    .dblclick(Gadfly.plot_dblclick)
-                    .mousewheel(Gadfly.guide_background_scroll)
-                    .drag(Gadfly.guide_background_drag_onmove,
-                          Gadfly.guide_background_drag_onstart,
-                          Gadfly.guide_background_drag_onend)
-                    """))]
+                  jscall("init_gadfly()"))]
 
     return tbl
 end


### PR DESCRIPTION
This adds a first version of box style zooming, as shown in the images below. It also works as expected when one or both dimensions are non-scalable. To initialize the zoom start dragging with the shift key pressed. You can cancel the zoom action by pressing escape (also works for panning).

As of now the box zoom is constrained to the the aspect ratio of the plot. I plan to fix this later by separating the scale factor for x and y.

<img width="524" alt="skarmavbild 2015-09-26 kl 12 51 21" src="https://cloud.githubusercontent.com/assets/847898/10117210/1a7bc136-644f-11e5-88c7-904219137d6d.png">
<img width="524" alt="skarmavbild 2015-09-26 kl 12 51 29" src="https://cloud.githubusercontent.com/assets/847898/10117211/2072c8d2-644f-11e5-8f73-4e181e33d9b1.png">
<img width="524" alt="skarmavbild 2015-09-26 kl 12 51 30" src="https://cloud.githubusercontent.com/assets/847898/10117214/2c7cf99a-644f-11e5-8646-e314eacc9c60.png">
