### PR TITLE
Resolve warning about use of Base.Nothing in v0.4.0

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -304,7 +304,7 @@ end
 # Returns:
 #   A Plot object.
 #
-function plot(data_source::@compat(Union{Nothing, AbstractMatrix, AbstractDataFrame}),
+function plot(data_source::@compat(Union{Void, AbstractMatrix, AbstractDataFrame}),
               mapping::Dict, elements::ElementOrFunctionOrLayers...)
     mapping = cleanmapping(mapping)
     p = Plot()


### PR DESCRIPTION
`using Gadfly` works on `v0.4.0` and `v0.3.2`

`v0.4.0` stil gives the following
```
WARNING: eval from module Compose to Gadfly:
Expr(:import, :Patchwork)::Any
  ** incremental compilation may be broken for this module **
```