### PR TITLE
Fixed y-axis bug for histogram2d

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -434,7 +434,7 @@ function apply_statistic(stat::Histogram2DStatistic,
                                             yminbincount, ymaxbincount)
 
     wx = x_categorial ? 1 : (x_max - x_min) / dx
-    wy = y_categorial ? 1 : (y_max - y_min) / dx
+    wy = y_categorial ? 1 : (y_max - y_min) / dy
 
     n = 0
     for cnt in bincounts


### PR DESCRIPTION
The size of the boxes for the `Geom.histogram2d` aesthetic was totally wrong - it was using the spacing for the x direction!