### PR TITLE
Use parse_colorant to handle arbitrary inputs (fixes #756)

### DIFF
--- a/src/geom/hline.jl
+++ b/src/geom/hline.jl
@@ -7,7 +7,7 @@ immutable HLineGeometry <: Gadfly.GeometryElement
     function HLineGeometry(; color=nothing,
                            size::@compat(Union{Measure, (@compat Void)})=nothing,
                            tag::Symbol=empty_tag)
-        new(color === nothing ? nothing : parse(Colorant, color),
+        new(color === nothing ? nothing : parse_colorant(color),
             size, tag)
     end
 end

--- a/src/geom/vline.jl
+++ b/src/geom/vline.jl
@@ -7,7 +7,7 @@ immutable VLineGeometry <: Gadfly.GeometryElement
     function VLineGeometry(; color=nothing,
                            size::Union{Measure, Void}=nothing,
                            tag::Symbol=empty_tag)
-        new(color === nothing ? nothing : parse(Colorant, color), size, tag)
+        new(color === nothing ? nothing : parse_colorant(color), size, tag)
     end
 end
 

--- a/src/geometry.jl
+++ b/src/geometry.jl
@@ -10,6 +10,7 @@ using Gadfly
 using Measures
 
 import Compose.combine # Prevent DataFrame.combine from taking over.
+using Compose.parse_colorant
 import Gadfly: render, layers, element_aesthetics, inherit, escape_id,
                default_statistic, default_scales, element_coordinate_type,
                ScaleElement, svg_color_class_from_label, isconcrete,

--- a/test/hline_vline.jl
+++ b/test/hline_vline.jl
@@ -4,5 +4,4 @@ using Gadfly
 plot(sin, 0, 25,
      xintercept=[0, pi, 2pi, 3pi],
      yintercept=[0, -1, 1],
-     Geom.hline, Geom.vline)
-
+     Geom.hline(color="red"), Geom.vline(color=colorant"black"))


### PR DESCRIPTION
CC @IainNZ. This is a more Gadfly-specific fix than https://github.com/JuliaGraphics/Colors.jl/pull/239, but it's unclear to me which should be preferred.

`parse_colorant` is [defined in Compose](https://github.com/dcjones/Compose.jl/blob/55eabfe21ed94c1a8b88babd4abfb444fb695ef6/src/Compose.jl#L64-L66), and is intended to provide the fallback behavior without introducing "dirty" methods to the Base-defined `parse` function.

