### PR TITLE
Implement manual bandwidth specification for KDEs

### DIFF
--- a/doc/geom_density.md
+++ b/doc/geom_density.md
@@ -12,11 +12,17 @@ Draw a kernel density estimate from data. An alias for `Geom.line` with
 
   * `x`: Sample to draw density estimate from.
 
+# Arguments
+
+  * bandwidth: How closely the density estimate should mirror the data.
+    Larger values will smooth the density estimate out.
+
 # Examples
 
 ```{.julia hide="true" results="none"}
 using RDatasets
 using Gadfly
+using Distributions
 
 Gadfly.set_default_plot_size(14cm, 8cm)
 ```
@@ -27,4 +33,14 @@ plot(dataset("ggplot2", "diamonds"), x="Price", Geom.density)
 
 ```julia
 plot(dataset("ggplot2", "diamonds"), x="Price", color="Cut", Geom.density)
+```
+
+```julia
+# adjusting bandwidth manually
+dist = MixtureModel(Normal, [(0.5, 0.2), (1, 0.1)])
+xs = rand(dist, 10^5)
+plot(layer(x=xs, Geom.density, Theme(default_color=colorant"orange")), 
+layer(x=xs, Geom.density(bandwidth=0.003), Theme(default_color=colorant"blue")),
+layer(x=xs, Geom.density(bandwidth=0.25), Theme(default_color=colorant"purple")),
+Guide.manual_color_key("bandwidth", ["auto", "bw=0.003", "bw=0.25"], ["orange", "blue", "purple"]))
 ```

--- a/src/geom/line.jl
+++ b/src/geom/line.jl
@@ -32,8 +32,8 @@ function path()
     return LineGeometry(preserve_order=true)
 end
 
-function density()
-    return LineGeometry(Gadfly.Stat.density())
+function density(; bandwidth::Real=-Inf)
+    return LineGeometry(Gadfly.Stat.density(bandwidth=bandwidth))
 end
 
 

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -463,9 +463,11 @@ end
 immutable DensityStatistic <: Gadfly.StatisticElement
     # Number of points sampled
     n::Int
+    # Bandwidth used for the kernel density estimation
+    bw::Real
 
-    function DensityStatistic(n=300)
-        new(n)
+    function DensityStatistic(; n=300, bandwidth=-Inf)
+        new(n, bandwidth)
     end
 end
 
@@ -497,9 +499,8 @@ function apply_statistic(stat::DensityStatistic,
         end
 
         x_f64 = collect(Float64, aes.x)
-        # When will stat.n ever be <= 1? Seems pointless
-        # certainly its length will always be 1
-        window = stat.n > 1 ? KernelDensity.default_bandwidth(x_f64) : 0.1
+
+        window = stat.bw <= 0.0 ? KernelDensity.default_bandwidth(x_f64) : stat.bw
         f = KernelDensity.kde(x_f64, bandwidth=window, npoints=stat.n)
         aes.x = collect(Float64, f.x)
         aes.y = f.density
@@ -517,7 +518,7 @@ function apply_statistic(stat::DensityStatistic,
         aes.x = Array(Float64, 0)
         aes.y = Array(Float64, 0)
         for (c, xs) in groups
-            window = stat.n > 1 ? KernelDensity.default_bandwidth(xs) : 0.1
+            window = stat.bw <= 0.0 ? KernelDensity.default_bandwidth(xs) : stat.bw
             f = KernelDensity.kde(xs, bandwidth=window, npoints=stat.n)
             append!(aes.x, f.x)
             append!(aes.y, f.density)

--- a/test/density.jl
+++ b/test/density.jl
@@ -1,5 +1,15 @@
 
-using Gadfly, DataArrays, RDatasets
+using Gadfly, DataArrays, RDatasets, Distributions
 
- plot(dataset("ggplot2", "diamonds"), x=:Price, Geom.density)
+plot(dataset("ggplot2", "diamonds"), x=:Price, Geom.density)
 
+# manual densities
+dist = MixtureModel(Normal, [(0.5, 0.2), (1, 0.1)])
+xs = rand(dist, 10^5)
+plot(layer(x=xs, Geom.density, Theme(default_color=colorant"orange")), 
+layer(x=xs, Geom.density(bandwidth=0.003),
+Theme(default_color=colorant"blue")),
+layer(x=xs, Geom.density(bandwidth=0.25),
+Theme(default_color=colorant"purple")),
+Guide.manual_color_key("bandwidth", ["auto", "bw=0.003", "bw=0.25"],
+["orange", "blue", "purple"]))


### PR DESCRIPTION
Other packages allow for manual specification of the bandwidth used by the kernel density estimator (e.g. [seaborn](https://stanford.edu/~mwaskom/software/seaborn/tutorial/distributions.html)). This PR exposes this option to the user.