### PR TITLE
Fix ArgumentError when plotting Geom.bar with empty array of values

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -196,6 +196,14 @@ function apply_statistic(stat::BarStatistic,
     end
 
     values = getfield(aes, var)
+    if isempty(getfield(aes, var))
+      setfield!(aes, minvar, Float64[1.0])
+      setfield!(aes, maxvar, Float64[1.0])
+      setfield!(aes, var, Float64[1.0])
+      setfield!(aes, othervar, Float64[0.0])
+      return
+    end
+
     iscontinuous = haskey(scales, var) && isa(scales[var], Scale.ContinuousScale)
     minvals, maxvals = barminmax(values, iscontinuous)
 

--- a/test/subplot_categorical_bar.jl
+++ b/test/subplot_categorical_bar.jl
@@ -7,4 +7,8 @@ plot(xgroup=["A", "A", "B", "B"],
      y=rand(4),
      Geom.subplot_grid(Geom.bar))
 
-
+plot(x=rand(3),
+     y=rand(3),
+     xgroup=["A", "A", "B"],
+     ygroup=["X", "Y", "Y"],
+     Geom.subplot_grid(Geom.bar))


### PR DESCRIPTION
The below code was resulting in `ArgumentError: reducing over an empty collection is not allowed` because there is no value where category1 is B and category2 is Y.

```julia
using Gadfly

Gadfly.plot(x=[1, 4, 2],
            y=[5, 7, 3],
            xgroup=["A", "A", "B"],
            ygroup=["X", "Y", "Y"],
            Geom.subplot_grid(Geom.bar))
```

I fixed this by copying the logic used in the HistogramStatistic version of apply_statistic and added a test.