### PR TITLE
RFC: Update contour usage

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,7 +3,7 @@ Codecs
 Colors 0.3.4
 Compat
 Compose 0.3.11
-Contour
+Contour 0.1.1
 DataFrames 0.4.2
 DataStructures
 Distributions

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1533,8 +1533,10 @@ function apply_statistic(stat::ContourStatistic,
             xc, yc = Contour.coordinates(line)
             append!(contour_xs, xc)
             append!(contour_ys, yc)
-            for _ in 1:length(xc); push!(groups, group); end
-            push!(levels, Contour.level(level))
+            for _ in 1:length(xc) 
+              push!(groups, group)
+              push!(levels, Contour.level(level))
+            end
             group += 1
         end
     end

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1528,14 +1528,13 @@ function apply_statistic(stat::ContourStatistic,
 
     groups = PooledDataArray(Int[])
     group = 0
-    for contour in Contour.contours(xs, ys, zs, stat.levels)
-        for curve in contour.lines
-            for v in curve.vertices
-                push!(contour_xs, v[1])
-                push!(contour_ys, v[2])
-                push!(levels, contour.level)
-                push!(groups, group)
-            end
+    for level in Contour.levels(Contour.contours(xs, ys, zs, stat.levels))
+        for line in Contour.lines(level)
+            xc, yc = Contour.coordinates(line)
+            append!(contour_xs, xc)
+            append!(contour_ys, yc)
+            for _ in 1:length(xc); push!(groups, group); end
+            push!(levels, Contour.level(level))
             group += 1
         end
     end


### PR DESCRIPTION
This updates the usage of Contour to the new API introduced v0.1.0, since the old API was removed in a v0.2.0 which is [about to be tagged](https://github.com/JuliaLang/METADATA.jl/pull/5901).

I wasn't able to get the tests to pass locally, but I'm not sure it's related to this change; if it is, I don't understand how. If the tests don't pass the CI builds here, I'd be glad for any help in figuring out why.