### PR TITLE
saner title spacing in SVG, fixes #863

### DIFF
--- a/src/guide.jl
+++ b/src/guide.jl
@@ -1045,8 +1045,8 @@ function render(guide::Title, theme::Gadfly.Theme,
 
     padding = 2mm
     ctx = compose!(
-        context(minwidth=text_width, minheight=text_height + 2padding),
-        text(0.5w, 1h - padding, guide.label, hcenter, vbottom),
+        context(minwidth=text_width, minheight=text_height + padding),
+        text(0.5w, 1h - text_height - padding, guide.label, hcenter, vtop),
         stroke(nothing),
         fill(theme.major_label_color),
         font(theme.major_label_font),


### PR DESCRIPTION
Currently, multiline titles simply spill-over onto the plot, which seems like a poor general solution. I believe a saner behavior is to increase the padding for the title above the plot:

New behavior:
<img width="380" alt="screen shot 2016-08-22 at 11 55 19" src="https://cloud.githubusercontent.com/assets/1661487/17867445/61881344-685f-11e6-91d1-2995c6528896.png">

Old behavior:

<img width="388" alt="screen shot 2016-08-22 at 11 56 42" src="https://cloud.githubusercontent.com/assets/1661487/17867483/8f537412-685f-11e6-8b72-0670df0cb9a8.png">

We might also want to consider exposing the padding variable to `Theme` so this becomes user adjustable.