### PR TITLE
fix inexacterrors caused by type coercion in broadcast

### DIFF
--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -1749,8 +1749,9 @@ function apply_statistic(stat::JitterStatistic,
     rng = MersenneTwister(stat.seed)
     for var in stat.vars
         data = getfield(aes, var)
-        broadcast!(+, data, data, stat.range * (rand(rng, length(data)) - 0.5) .* span)
-        setfield!(aes, var, data)
+        outdata = Array(Float64, size(data))
+        broadcast!(+, outdata, data, stat.range * (rand(rng, length(data)) - 0.5) .* span)
+        setfield!(aes, var, outdata)
     end
 end
 

--- a/test/jitter.jl
+++ b/test/jitter.jl
@@ -4,4 +4,6 @@ using Gadfly, DataArrays, RDatasets
 plot(dataset("datasets", "iris"), x=:SepalLength, y=:SepalWidth, color=:Species,
      Stat.x_jitter, Stat.y_jitter, Geom.point)
 
-
+# make sure type-coercion works properly, the `y` values here are integers
+# but will be coerced into floats.
+plot(x=rand(500), y=rand(1:4, 500), Stat.y_jitter(range=0.5), Geom.point)


### PR DESCRIPTION
The following plot fails on master, but is in our documentation:

```julia
julia> using Gadfly

julia> plot(x=rand(500), y=rand(1:4, 500), Stat.y_jitter(range=0.5), Geom.point)
Error showing value of type Gadfly.Plot:
ERROR: InexactError()
 in macro expansion at ./broadcast.jl:129 [inlined]
 in macro expansion at ./simdloop.jl:73 [inlined]
 in macro expansion at ./broadcast.jl:123 [inlined]
 in _broadcast!(::Base.#+, ::Array{Int64,1}, ::Tuple{Tuple{Bool},Tuple{Bool}}, ::Tuple{Tuple{Int64},Tuple{Int64}}, ::Tuple{Array{Int64,1},Array{Float64,1}}, ::Type{Val{2}}) at ./broadcast.jl:117
 in broadcast!(::Function, ::Array{Int64,1}, ::Array{Int64,1}, ::Array{Float64,1}) at ./broadcast.jl:172
 in apply_statistic(::Gadfly.Stat.JitterStatistic, ::Dict{Symbol,Gadfly.ScaleElement}, ::Gadfly.Coord.Cartesian, ::Gadfly.Aesthetics) at /Users/tamasnagy/.julia/v0.5/Gadfly/src/statistics.jl:1752
 in apply_statistics(::Array{Gadfly.StatisticElement,1}, ::Dict{Symbol,Gadfly.ScaleElement}, ::Gadfly.Coord.Cartesian, ::Gadfly.Aesthetics) at /Users/tamasnagy/.julia/v0.5/Gadfly/src/statistics.jl:38
 in render_prepare(::Gadfly.Plot) at /Users/tamasnagy/.julia/v0.5/Gadfly/src/Gadfly.jl:740
 in render(::Gadfly.Plot) at /Users/tamasnagy/.julia/v0.5/Gadfly/src/Gadfly.jl:799
 in display(::Base.REPL.REPLDisplay{Base.REPL.LineEditREPL}, ::MIME{Symbol("text/html")}, ::Gadfly.Plot) at /Users/tamasnagy/.julia/v0.5/Gadfly/src/Gadfly.jl:1062
 in macro expansion at ./multimedia.jl:143 [inlined]
 in display(::Gadfly.Plot) at /Users/tamasnagy/.julia/v0.5/Gadfly/src/Gadfly.jl:1014
 in print_response(::Base.Terminals.TTYTerminal, ::Any, ::Void, ::Bool, ::Bool, ::Void) at ./REPL.jl:154
 in print_response(::Base.REPL.LineEditREPL, ::Any, ::Void, ::Bool, ::Bool) at ./REPL.jl:139
 in (::Base.REPL.##22#23{Bool,Base.REPL.##33#42{Base.REPL.LineEditREPL,Base.REPL.REPLHistoryProvider},Base.REPL.LineEditREPL,Base.LineEdit.Prompt})(::Base.LineEdit.MIState, ::Base.AbstractIOBuffer{Array{UInt8,1}}, ::Bool) at ./REPL.jl:652
 in run_interface(::Base.Terminals.TTYTerminal, ::Base.LineEdit.ModalInterface) at ./LineEdit.jl:1579
 in run_interface(::Base.Terminals.TTYTerminal, ::Base.LineEdit.ModalInterface) at /Applications/Julia-0.5.app/Contents/Resources/julia/lib/julia/sys.dylib:?
 in run_frontend(::Base.REPL.LineEditREPL, ::Base.REPL.REPLBackendRef) at ./REPL.jl:903
 in run_repl(::Base.REPL.LineEditREPL, ::Base.##930#931) at ./REPL.jl:188
 in _start() at ./client.jl:360
 in _start() at /Applications/Julia-0.5.app/Contents/Resources/julia/lib/julia/sys.dylib:?
```
https://dcjones.github.io/Gadfly.jl/stat_y_jitter.html

This PR fixes this problem. Working towards #879.