### PR TITLE
prevent stackoverflow in color_discrete_manual, fixes #844

### DIFF
--- a/src/scale.jl
+++ b/src/scale.jl
@@ -524,7 +524,7 @@ const color_discrete = color_discrete_hue
 @deprecate discrete_color(; levels=nothing, order=nothing, preserve_order=true) color_discrete(; levels=levels, order=order, preserve_order=preserve_order)
 
 
-color_discrete_manual(colors...; levels=nothing, order=nothing) = color_discrete_manual(map(Gadfly.parse_colorant, colors)...; levels=levels, order=order)
+color_discrete_manual(colors::AbstractString...; levels=nothing, order=nothing) = color_discrete_manual(map(Gadfly.parse_colorant, colors)...; levels=levels, order=order)
 
 function color_discrete_manual(colors::Color...; levels=nothing, order=nothing)
     cs = [colors...]

--- a/test/discrete_color_manual.jl
+++ b/test/discrete_color_manual.jl
@@ -1,7 +1,8 @@
-
 using Gadfly
+using Colors
+using Base.Test
 
+# This should throw a MethodError, not a stackoverflow
+@test_throws MethodError Scale.color_discrete_manual([RGBA(0,0,0,0.1)])
 
 plot([sin, cos], 0, 25, Scale.color_discrete_manual("red", "purple"))
-
-


### PR DESCRIPTION
Throws a `MethodError` if the correct `color_discrete_manual` function isn't found instead of crashing.