### PR TITLE
Fix MethodError in Travis for Julia v0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ script:
 after_success:
   - julia -e 'cd(Pkg.dir("Gadfly")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   - julia -e 'Pkg.checkout("Compose")'
-  - julia -e 'cd(Pkg.dir("Gadfly")); map(x->Pkg.add(strip(x)), readlines(joinpath("docs", "REQUIRE")))'
+  - julia -e 'cd(Pkg.dir("Gadfly")); map(x->Pkg.add(strip(x)), readlines(open(joinpath("docs", "REQUIRE"))))'
   - julia -e 'cd(Pkg.dir("Gadfly")); include(joinpath("docs", "make.jl"))'


### PR DESCRIPTION
The v0.4 jobs (https://travis-ci.org/dcjones/Gadfly.jl/jobs/159108969 on line 1565) throw `MethodError` because `readlines` does not take a filename string as an argument in v0.4:

```bash
ERROR: MethodError: `eachline` has no method matching eachline(::ASCIIString)
 in readlines at io.jl:289
 in process_options at ./client.jl:257
 in _start at ./client.jl:378
```

The exact implementation in v0.4:

```julia
readlines(s=STDIN) = collect(eachline(s))
```

This change should work for both v0.4 and v0.5.