### PR TITLE
Display in Juno

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -14,3 +14,4 @@ KernelDensity
 Loess
 Showoff 0.0.3
 StatsBase
+Juno

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -134,7 +134,7 @@ Creates layers based on elements
 
 ### Args
 * data_source: The data source as a dataframe
-* elements: The elements 
+* elements: The elements
 * mapping: mapping
 
 ### Returns
@@ -1105,6 +1105,20 @@ function display(d::REPLDisplay, ::MIME"application/pdf", p::Plot)
     open_file(filename)
 end
 
+# Display in Juno
+
+using Juno
+
+@render Juno.PlotPane p::Plot begin
+  x, y = Juno.plotsize()
+  set_default_plot_size(x*Gadfly.px, y*Gadfly.px)
+  div(d(:style=>"background: white"),
+      HTML(stringmime("text/html", p)))
+end
+
+@render Juno.Editor p::Gadfly.Plot begin
+  Juno.icon("graph")
+end
 
 include("scale.jl")
 include("coord.jl")

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -1107,13 +1107,15 @@ end
 
 # Display in Juno
 
-using Juno
+import Juno: Juno, @render, media, Media, Hiccup
+
+media(Plot, Media.Plot)
 
 @render Juno.PlotPane p::Plot begin
   x, y = Juno.plotsize()
   set_default_plot_size(x*Gadfly.px, y*Gadfly.px)
-  div(d(:style=>"background: white"),
-      HTML(stringmime("text/html", p)))
+  Hiccup.div(Dict(:style=>"background: white"),
+                  HTML(stringmime("text/html", p)))
 end
 
 @render Juno.Editor p::Gadfly.Plot begin


### PR DESCRIPTION
This adds a small, pure-Julia dependency on Juno.jl which enables Gadfly to be display appropriately in the Juno plot pane.