### PR TITLE
fixed show methods using Cairo for julia v0.5

### DIFF
--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -969,18 +969,16 @@ end
 
 try
     getfield(Compose, :Cairo) # throws if Cairo isn't being used
-    @compat function show(io::IO, ::MIME"image/png", p::Plot)
+    @compat global show(io::IO, ::MIME"image/png", p::Plot) =
         draw(PNG(io, Compose.default_graphic_width,
-                 Compose.default_graphic_height), p)
-    end
+                 Compose.default_graphic_height), p);
 end
 
 try
     getfield(Compose, :Cairo) # throws if Cairo isn't being used
-    @compat function show(io::IO, ::MIME"application/postscript", p::Plot)
+    @compat global show(io::IO, ::MIME"application/postscript", p::Plot) =
         draw(PS(io, Compose.default_graphic_width,
-             Compose.default_graphic_height), p)
-    end
+             Compose.default_graphic_height), p);
 end
 
 @compat function show(io::IO, ::MIME"text/plain", p::Plot)

--- a/src/Gadfly.jl
+++ b/src/Gadfly.jl
@@ -969,16 +969,20 @@ end
 
 try
     getfield(Compose, :Cairo) # throws if Cairo isn't being used
-    @compat global show(io::IO, ::MIME"image/png", p::Plot) =
+    global show
+    @compat function show(io::IO, ::MIME"image/png", p::Plot)
         draw(PNG(io, Compose.default_graphic_width,
-                 Compose.default_graphic_height), p);
+                 Compose.default_graphic_height), p)
+    end
 end
 
 try
     getfield(Compose, :Cairo) # throws if Cairo isn't being used
-    @compat global show(io::IO, ::MIME"application/postscript", p::Plot) =
+    global show
+    @compat function show(io::IO, ::MIME"application/postscript", p::Plot)
         draw(PS(io, Compose.default_graphic_width,
              Compose.default_graphic_height), p);
+    end
 end
 
 @compat function show(io::IO, ::MIME"text/plain", p::Plot)


### PR DESCRIPTION
Try blocks behave differently in julia v0.5 compared to v0.4. The new
behaviour caused the show methods requiring Cairo to be defined in
local scope instead of global scope, which in turn prevented them from
being used. See also:
  https://github.com/JuliaLang/julia/issues/18767