### PR TITLE
limit building docs to linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,4 @@ script:
 after_success:
   - julia -e 'cd(Pkg.dir("Gadfly")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   - julia -e 'Pkg.checkout("Compose")'
-  - julia -e 'cd(Pkg.dir("Gadfly")); map(x->Pkg.add(strip(x)), readlines(open(joinpath("docs", "REQUIRE"))))'
-  - julia -e 'cd(Pkg.dir("Gadfly")); include(joinpath("docs", "make.jl"))'
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; julia -e 'cd(Pkg.dir("Gadfly")); map(x->Pkg.add(strip(x)), readlines(open(joinpath("docs", "REQUIRE")))); include(joinpath("docs", "make.jl"))'; fi


### PR DESCRIPTION
Tests are running pretty slow because currently docs are being built on all platforms. This only really needs to happen on linux. The Travis build-bots for OS X also seem slower so this compounds the issue. It might be good to move coveralls testing to linux only too. 