### PR TITLE
fix world age errors in tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,7 +85,7 @@ testfiles = isempty(ARGS) ?
         @test typeof(p) in [Plot,Compose.Context]
         for (backend_name, backend) in backends
             @info string(filename,'.',backend_name)
-            r = draw(backend(filename), p)
+            r = Base.invokelatest(draw, backend(filename), p)
             @test typeof(r) in [Bool,Nothing]
         end
     end


### PR DESCRIPTION
There is some difference in how world ages are handled on 1.12 and this evals a file inside a block so the definitions in there are in general not visible to code in the same block where the world age has not gotten the chance to be bumped. This makes the tests pass on 1.12 again.